### PR TITLE
release v2.0.0-rc.2: address Critical issues #9 #17 #21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@laststance/electron-mcp-server",
-  "version": "1.7.0",
+  "version": "2.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@laststance/electron-mcp-server",
-      "version": "1.7.0",
+      "version": "2.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@laststance/electron-mcp-server",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "MCP server for Electron application automation and management. See MCP_USAGE_GUIDE.md for proper argument structure examples.",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/navigate/navigate-to-hash.ts
+++ b/src/commands/navigate/navigate-to-hash.ts
@@ -13,8 +13,14 @@ const schema = z.object({
 });
 
 /**
- * Navigate to a hash route via `history.pushState` + manual `hashchange`
- * dispatch (so React Router and similar listeners pick up the change).
+ * Navigate to a hash route via `history.pushState` followed by both `hashchange`
+ * and `popstate` dispatch.
+ *
+ * Why two events: legacy listeners (and code that wraps `window.location.hash`)
+ * watch `hashchange`, but react-router-dom v7's `HashRouter` (and other
+ * `createHashHistory` consumers) primarily subscribe to `popstate`. Issue #17
+ * showed the URL bar updating while `useLocation()` stayed on the old route
+ * because `pushState` does not fire `popstate` natively.
  *
  * Sanitization rejects `javascript:`, `<script`, and full URLs (`://`) to
  * keep this strictly an in-app navigation.
@@ -22,7 +28,7 @@ const schema = z.object({
 export const navigateToHash = defineCommand({
   name: 'electron_navigate_to_hash',
   description:
-    'Navigate to a hash route (e.g., "#create"). Uses pushState + manual hashchange so React Router picks it up.',
+    'Navigate to a hash route (e.g., "#create"). Uses pushState + manual hashchange + popstate dispatch so both legacy listeners and react-router-dom v7 HashRouter pick it up.',
   schema,
   operationType: 'command',
   async execute(args, target) {
@@ -43,13 +49,18 @@ export const navigateToHash = defineCommand({
       (function() {
         try {
           if (window.history && window.history.pushState) {
+            const oldHref = window.location.href;
             const newUrl = window.location.pathname + window.location.search + ${hashLiteral};
             window.history.pushState({}, '', newUrl);
 
             window.dispatchEvent(new HashChangeEvent('hashchange', {
               newURL: window.location.href,
-              oldURL: window.location.href.replace(${hashLiteral}, '')
+              oldURL: oldHref
             }));
+
+            // react-router-dom v7 HashRouter (createHashHistory) listens on popstate.
+            // pushState does not fire popstate natively, so dispatch it manually.
+            window.dispatchEvent(new PopStateEvent('popstate', { state: null }));
 
             return 'Navigated to hash: ' + ${hashLiteral};
           } else {

--- a/src/security/validation.ts
+++ b/src/security/validation.ts
@@ -204,7 +204,13 @@ export class InputValidator {
   }
 
   /**
-   * Special validation for eval commands - validates the actual code to be executed
+   * Special validation for eval commands - validates the actual code to be executed.
+   *
+   * Defense-in-depth: DANGEROUS_KEYWORDS are screened on every eval payload regardless
+   * of whether it matches a `safePatterns` shortcut, because the generic property-access
+   * pattern (`/^[\w.[\]'"]+$/`) was previously letting `process.platform`,
+   * `globalThis.foo`, `__proto__.constructor` etc. through unchecked (Issue #9).
+   * The function-call / assignment / obfuscation checks are still gated by `isSafe`.
    */
   private static validateEvalContent(code: string): {
     errors: string[];
@@ -213,6 +219,15 @@ export class InputValidator {
     const errors: string[] = [];
     const riskFactors: string[] = [];
     const profile = SECURITY_PROFILES[this.securityLevel];
+
+    // Defense-in-depth: dangerous-keyword screening runs unconditionally.
+    for (const keyword of this.DANGEROUS_KEYWORDS) {
+      const regex = new RegExp(`\\b${keyword}\\b`, 'gi');
+      if (regex.test(code)) {
+        errors.push(`Dangerous keyword detected in eval: ${keyword}`);
+        riskFactors.push(`eval_dangerous_keyword_${keyword}`);
+      }
+    }
 
     // Allow simple safe operations
     const safePatterns = [
@@ -253,15 +268,6 @@ export class InputValidator {
       uiInteractionPatterns.some((pattern) => pattern.test(code.trim()));
 
     if (!isSafe) {
-      // Check for dangerous keywords in eval content
-      for (const keyword of this.DANGEROUS_KEYWORDS) {
-        const regex = new RegExp(`\\b${keyword}\\b`, 'gi');
-        if (regex.test(code)) {
-          errors.push(`Dangerous keyword detected in eval: ${keyword}`);
-          riskFactors.push(`eval_dangerous_keyword_${keyword}`);
-        }
-      }
-
       // Check for function calls based on security profile
       const hasFunctionCall = /\(\s*\)|\w+\s*\(/.test(code);
       if (hasFunctionCall) {
@@ -282,8 +288,11 @@ export class InputValidator {
         }
       }
 
-      // Check for assignment operations based on security profile
-      if (/=(?!=)/.test(code) && !profile.allowAssignments) {
+      // Match a real assignment `=` while excluding the comparison and arrow forms:
+      //   ==, ===, !=, !==, <=, >=, =>
+      // Lookbehind rejects `=` after [=!<>]; lookahead rejects `=` before [=>].
+      // Issue #21: previous `/=(?!=)/` flagged `===`/`!==`/arrow funcs as assignments.
+      if (/(?<![=!<>])=(?![=>])/.test(code) && !profile.allowAssignments) {
         errors.push(`Assignment operations in eval are restricted`);
         riskFactors.push('eval_assignment');
       }

--- a/src/security/validation.ts
+++ b/src/security/validation.ts
@@ -75,6 +75,32 @@ export class InputValidator {
     'globalThis',
   ];
 
+  /**
+   * Subset of identifiers that must never appear in any eval payload, regardless
+   * of the security level or `safePatterns` allowlist. Compared to the broader
+   * {@link DANGEROUS_KEYWORDS} (used for non-eval command content), this list
+   * intentionally excludes Node.js module names that collide with legitimate
+   * web platform identifiers (`url` ↔ `document.URL`, `crypto` ↔ `window.crypto`,
+   * `path` ↔ pathname helpers, etc.) so we don't reject documented safe payloads
+   * while still catching the prototype-pollution / process-escape primitives that
+   * Issue #9 was about.
+   */
+  private static readonly EVAL_CRITICAL_KEYWORDS = [
+    'Function',
+    'constructor',
+    '__proto__',
+    'prototype',
+    'process',
+    'require',
+    'import',
+    'global',
+    'globalThis',
+    'child_process',
+    'worker_threads',
+    'vm',
+    'repl',
+  ];
+
   private static readonly XSS_PATTERNS = [
     /<script[^>]*>[\s\S]*?<\/script>/gi,
     /javascript:/gi,
@@ -206,11 +232,14 @@ export class InputValidator {
   /**
    * Special validation for eval commands - validates the actual code to be executed.
    *
-   * Defense-in-depth: DANGEROUS_KEYWORDS are screened on every eval payload regardless
-   * of whether it matches a `safePatterns` shortcut, because the generic property-access
-   * pattern (`/^[\w.[\]'"]+$/`) was previously letting `process.platform`,
-   * `globalThis.foo`, `__proto__.constructor` etc. through unchecked (Issue #9).
-   * The function-call / assignment / obfuscation checks are still gated by `isSafe`.
+   * Defense-in-depth: {@link EVAL_CRITICAL_KEYWORDS} are screened on every eval
+   * payload regardless of whether it matches a `safePatterns` shortcut, because
+   * the generic property-access pattern (`/^[\w.[\]'"]+$/`) was previously letting
+   * `process.platform`, `globalThis.foo`, `__proto__.constructor` etc. through
+   * unchecked (Issue #9). The list is intentionally narrower than the broader
+   * `DANGEROUS_KEYWORDS` used by `validateCommandContent`, so legitimate web
+   * platform expressions like `document.URL` are not flagged. The function-call
+   * / assignment / obfuscation checks are still gated by `isSafe`.
    */
   private static validateEvalContent(code: string): {
     errors: string[];
@@ -220,9 +249,12 @@ export class InputValidator {
     const riskFactors: string[] = [];
     const profile = SECURITY_PROFILES[this.securityLevel];
 
-    // Defense-in-depth: dangerous-keyword screening runs unconditionally.
-    for (const keyword of this.DANGEROUS_KEYWORDS) {
-      const regex = new RegExp(`\\b${keyword}\\b`, 'gi');
+    // Defense-in-depth: scan only the eval-critical subset unconditionally so we
+    // catch prototype-pollution / process-escape primitives (Issue #9) without
+    // false-positiving identifiers shared with the web platform (Issue: PR #22
+    // CodeRabbit feedback — `document.URL` was being rejected by `\burl\b`).
+    for (const keyword of this.EVAL_CRITICAL_KEYWORDS) {
+      const regex = new RegExp(`\\b${keyword}\\b`, 'g');
       if (regex.test(code)) {
         errors.push(`Dangerous keyword detected in eval: ${keyword}`);
         riskFactors.push(`eval_dangerous_keyword_${keyword}`);

--- a/src/security/validation.ts
+++ b/src/security/validation.ts
@@ -320,11 +320,23 @@ export class InputValidator {
         }
       }
 
-      // Match a real assignment `=` while excluding the comparison and arrow forms:
-      //   ==, ===, !=, !==, <=, >=, =>
-      // Lookbehind rejects `=` after [=!<>]; lookahead rejects `=` before [=>].
-      // Issue #21: previous `/=(?!=)/` flagged `===`/`!==`/arrow funcs as assignments.
-      if (/(?<![=!<>])=(?![=>])/.test(code) && !profile.allowAssignments) {
+      // Detect any assignment operator while excluding the comparison and arrow
+      // forms (`==`, `===`, `!=`, `!==`, `<=`, `>=`, `=>`).
+      //
+      // The standalone `=` branch uses a negative lookbehind (rejects `=` after
+      // `[=!<>]`) plus a negative lookahead (rejects `=` before `[=>]`).
+      // Issue #21: the previous `/=(?!=)/` flagged `===`/`!==`/arrow funcs as
+      // assignments.
+      //
+      // Compound assignment operators must be matched explicitly, because the
+      // lookbehind only inspects the single character before `=` — for `<<=`
+      // the `=` is preceded by `<`, which sits in the lookbehind exclusion set
+      // and would otherwise let `a <<= 1` bypass `allowAssignments` (PR #22
+      // CodeRabbit round 2). Longest alternatives are listed first so the
+      // engine prefers e.g. `>>>=` over the `>>=` substring.
+      const assignmentPattern =
+        /<<=|>>>=|>>=|\*\*=|&&=|\|\|=|\?\?=|[+\-*/%&|^]=|(?<![=!<>])=(?![=>])/;
+      if (assignmentPattern.test(code) && !profile.allowAssignments) {
         errors.push(`Assignment operations in eval are restricted`);
         riskFactors.push('eval_assignment');
       }

--- a/tests/unit/input-validator.test.ts
+++ b/tests/unit/input-validator.test.ts
@@ -112,4 +112,39 @@ describe('InputValidator.validateCommand (eval payloads)', () => {
       );
     });
   });
+
+  describe('PR #22 round 2 — compound assignment operators', () => {
+    // The previous fix used `/(?<![=!<>])=(?![=>])/`, whose lookbehind only
+    // inspects one character. `<<=`, `>>=`, `>>>=` therefore slipped through
+    // because the `=` is preceded by `<` or `>`, which sit in the lookbehind
+    // exclusion set. The new pattern lists all compound operators explicitly.
+    const compoundAssignments = [
+      'window.foo += 1',
+      'window.foo -= 1',
+      'window.foo *= 2',
+      'window.foo /= 2',
+      'window.foo %= 2',
+      'window.foo **= 2',
+      'window.foo <<= 1',
+      'window.foo >>= 1',
+      'window.foo >>>= 1',
+      'window.foo &= 1',
+      'window.foo |= 1',
+      'window.foo ^= 1',
+      'window.foo &&= 1',
+      'window.foo ||= 1',
+      'window.foo ??= 1',
+    ];
+
+    it.each(compoundAssignments)('rejects compound assignment: %s', (code) => {
+      const result = InputValidator.validateCommand({
+        command: code,
+        operationType: 'eval',
+      });
+
+      expect(result.errors.some((message) => message.includes('Assignment operations'))).toBe(
+        true,
+      );
+    });
+  });
 });

--- a/tests/unit/input-validator.test.ts
+++ b/tests/unit/input-validator.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { InputValidator } from '../../src/security/validation';
+import { SecurityLevel } from '../../src/security/config';
+
+/**
+ * Unit tests for the eval-content branch of {@link InputValidator.validateCommand}.
+ *
+ * Covers two regressions found during v2.0.0-rc.1 QA:
+ *   - Issue #9: dangerous-keyword screening was short-circuited by `safePatterns`,
+ *     letting `process.platform` etc. pass.
+ *   - Issue #21: assignment regex flagged `===`/`!==`/`<=`/`>=`/`=>` as assignments.
+ *
+ * Each test calls `validateCommand` with `operationType: 'eval'` and checks
+ * `isValid` plus the surface form of `errors`.
+ */
+describe('InputValidator.validateCommand (eval payloads)', () => {
+  beforeEach(() => {
+    // BALANCED is the default profile users hit in production. RC2 fixes target this profile.
+    InputValidator.setSecurityLevel(SecurityLevel.BALANCED);
+  });
+
+  describe('Issue #9 — dangerous-keyword defense-in-depth', () => {
+    const dangerousPayloads = [
+      'process.platform',
+      'process.env.HOME',
+      'process.versions.node',
+      'global.someVar',
+      'globalThis.foo',
+      '__proto__.constructor',
+      'require("os")',
+    ];
+
+    it.each(dangerousPayloads)('rejects dangerous global access: %s', (code) => {
+      const result = InputValidator.validateCommand({
+        command: code,
+        operationType: 'eval',
+      });
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors.some((message) => message.includes('Dangerous keyword'))).toBe(true);
+      expect(result.riskLevel).toBe('critical');
+    });
+
+    const safePayloads = [
+      'document.title',
+      'window.location.href',
+      'Math.PI',
+      'Date.now',
+      'JSON.stringify',
+    ];
+
+    it.each(safePayloads)('still allows known-safe pattern: %s', (code) => {
+      const result = InputValidator.validateCommand({
+        command: code,
+        operationType: 'eval',
+      });
+
+      expect(result.errors).toEqual([]);
+      expect(result.isValid).toBe(true);
+    });
+  });
+
+  describe('Issue #21 — comparison/arrow operators are not assignments', () => {
+    const comparisonPayloads = [
+      'document.title === "QA Fixture"',
+      'document.title !== "x"',
+      'document.querySelectorAll("a").length >= 5',
+      'document.querySelectorAll("a").length <= 5',
+      'document.querySelectorAll("a").length > 0',
+      'document.querySelectorAll("a").length < 100',
+    ];
+
+    it.each(comparisonPayloads)('does not flag comparison as assignment: %s', (code) => {
+      const result = InputValidator.validateCommand({
+        command: code,
+        operationType: 'eval',
+      });
+
+      expect(result.errors.some((message) => message.includes('Assignment operations'))).toBe(
+        false,
+      );
+    });
+
+    it('does not flag arrow functions as assignment', () => {
+      // Arrow functions on their own are still rejected for "function calls in eval are restricted",
+      // but the assignment check should not contribute. Check the assignment error specifically.
+      const result = InputValidator.validateCommand({
+        command: 'document.querySelectorAll("a").forEach(a => a.id)',
+        operationType: 'eval',
+      });
+
+      expect(result.errors.some((message) => message.includes('Assignment operations'))).toBe(
+        false,
+      );
+    });
+
+    it('still rejects real assignments', () => {
+      const result = InputValidator.validateCommand({
+        command: 'window.foo = 1',
+        operationType: 'eval',
+      });
+
+      expect(result.errors.some((message) => message.includes('Assignment operations'))).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/tests/unit/input-validator.test.ts
+++ b/tests/unit/input-validator.test.ts
@@ -47,6 +47,13 @@ describe('InputValidator.validateCommand (eval payloads)', () => {
       'Math.PI',
       'Date.now',
       'JSON.stringify',
+      // PR #22 CodeRabbit follow-up: the unconditional dangerous-keyword scan
+      // previously matched `\burl\b` case-insensitively and rejected the
+      // documented `document.URL` shortcut. The narrowed EVAL_CRITICAL_KEYWORDS
+      // list (no `url`/`crypto`/`path`/etc.) keeps this safe.
+      'document.URL',
+      'document.domain',
+      'window.location',
     ];
 
     it.each(safePayloads)('still allows known-safe pattern: %s', (code) => {

--- a/tests/unit/navigate-to-hash.test.ts
+++ b/tests/unit/navigate-to-hash.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { executeInElectronSpy } = vi.hoisted(() => ({
+  executeInElectronSpy: vi.fn(async () => 'mocked'),
+}));
+
+vi.mock('../../src/utils/electron-connection', () => ({
+  executeInElectron: executeInElectronSpy,
+}));
+
+import { navigateToHash } from '../../src/commands/navigate/navigate-to-hash';
+
+/**
+ * Issue #17: react-router-dom v7 HashRouter listens on `popstate`, but
+ * `pushState` does not fire `popstate` natively. We dispatch it manually so the
+ * router's `useLocation()` updates after navigation. Also keep `hashchange` for
+ * legacy listeners.
+ */
+describe('navigate_to_hash generated JS', () => {
+  beforeEach(() => {
+    executeInElectronSpy.mockClear();
+  });
+
+  it('dispatches both hashchange and popstate after pushState', async () => {
+    await navigateToHash.execute({ hash: '/forms' }, {});
+
+    expect(executeInElectronSpy).toHaveBeenCalledTimes(1);
+    const generatedCode = executeInElectronSpy.mock.calls[0][0] as string;
+
+    expect(generatedCode).toMatch(/window\.history\.pushState\(/);
+    expect(generatedCode).toMatch(/new HashChangeEvent\('hashchange'/);
+    expect(generatedCode).toMatch(/new PopStateEvent\('popstate'/);
+  });
+
+  it('rejects javascript: hash without invoking executeInElectron', async () => {
+    const result = await navigateToHash.execute({ hash: 'javascript:alert(1)' }, {});
+
+    expect(result).toBe('Invalid hash: contains dangerous content');
+    expect(executeInElectronSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to location.hash when pushState unavailable', async () => {
+    await navigateToHash.execute({ hash: '/secondary' }, {});
+    const generatedCode = executeInElectronSpy.mock.calls[0][0] as string;
+
+    expect(generatedCode).toMatch(/window\.location\.hash =/);
+  });
+});


### PR DESCRIPTION
## Summary

RC2 release candidate. Fixes the three Critical issues caught during v2.0.0-rc.1 实机 QA on `skills-desktop` and `playground/qa-fixture/`:

- 🔴 **Closes #9** — `validateEvalContent` short-circuited dangerous-keyword screening when a payload matched a `safePatterns` shortcut. The generic property-access pattern (`/^[\w.[\]'"]+$/`) was letting `process.platform`, `globalThis.foo`, `__proto__.constructor` etc. pass unchecked. Defense-in-depth screening now runs unconditionally.
- 🔴 **Closes #17** — `electron_navigate_to_hash` updated the URL via `pushState` and dispatched `hashchange`, but react-router-dom v7 `HashRouter` (`createHashHistory`) listens primarily on `popstate`, which `pushState` does not fire natively. We now dispatch a synthetic `PopStateEvent` in addition, so React Router updates `useLocation()` after navigation.
- 🔴 **Closes #21** — assignment-detection regex `/=(?!=)/` flagged `===` / `!==` / `<=` / `>=` / `=>` as assignments, blocking comparisons in `electron_eval` and `electron_wait_for_function`. Switched to `/(?<![=!<>])=(?![=>])/` which excludes both comparison and arrow-function forms.

Bumps `package.json` to `2.0.0-rc.2`. The final commit `release v2.0.0-rc.2` will trigger `.github/workflows/release.yml` after squash merge so npm publishes under the `rc` dist-tag (latest stays at 1.7.1).

## Test plan

- [x] `npm run code:check` — lint + format-check clean
- [x] `npm test` (unit suite) — 97/97 pass, including new `tests/unit/input-validator.test.ts` (20 cases) and `tests/unit/navigate-to-hash.test.ts` (3 cases)
- [x] `npm run build` — webpack production build succeeds
- [ ] CI `malware-safe-chain` green
- [ ] CodeRabbit review pass
- [ ] Post-merge: confirm `release.yml` publishes `2.0.0-rc.2` to npm `rc` dist-tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigation now dispatches both popstate and hashchange events for more reliable route updates.
  * Eval validation now always screens for a curated set of dangerous keywords and tightens assignment detection.

* **Chores**
  * Package version bumped to 2.0.0-rc.2.

* **Tests**
  * Added unit tests covering eval validation and navigation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->