### PR TITLE
docs: press_key macOS shortcut limit + click rate-limit clarifications (#12, #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,8 @@ See [SECURITY_CONFIG.md](./SECURITY_CONFIG.md) for detailed security documentati
 | "The provided selector is empty" | Passing string instead of object | Use `{"selector": "..."}`      |
 | "Element not found"              | Wrong selector                   | Use `get_page_structure` first |
 | "Command blocked"                | Security restriction             | Check security level settings  |
-| "Click prevented - too soon"     | Rapid consecutive clicks         | Wait before retrying           |
+| "Click prevented - too soon after previous click" | Same target clicked within `~1s` (`click_by_selector`) / `~2s` (`click_by_text`) — intentional React anti-double-submit debounce | Serialize calls (`await` each) or pass a different selector / text |
+| `Cmd+A` / `Cmd+C` / `Cmd+V` does nothing in `electron_press_key` | macOS OS-level text-editing shortcuts are bypassed by CDP `Input.dispatchKeyEvent` (synthetic events only — same constraint as Playwright) | Use `electron_eval` with `el.select()` / `el.setSelectionRange(...)` / `navigator.clipboard.*`; for app-level hotkeys use `electron_send_keyboard_shortcut` |
 
 ## 🛠️ Security Features
 

--- a/src/commands/click/click-by-selector.ts
+++ b/src/commands/click/click-by-selector.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { CLICK_BY_SELECTOR_RATE_LIMIT_MS } from '../../constants';
 import { executeInElectron } from '../../utils/electron-connection';
 import { containsDangerousContent, escapeJsString } from '../shared/escaping';
 import { windowTargetFields } from '../shared/window-target';
@@ -18,14 +19,20 @@ const schema = z.object({
  * Replaces the old `click_button` subcommand (T14) — `click_button` defaulted
  * the selector to `'button'` and polluted `window[mcp_click_*]` with rate-limit
  * markers plus a `pointerEvents` hack. This command keeps a lightweight
- * 1-second debounce (`window[mcp_selector_click_*]`) but drops the worst of
- * those workarounds; callers needing the old behavior should pass an explicit
- * selector like `'button'`.
+ * `CLICK_BY_SELECTOR_RATE_LIMIT_MS` debounce (`window[mcp_selector_click_*]`)
+ * but drops the worst of those workarounds; callers needing the old behavior
+ * should pass an explicit selector like `'button'`.
+ *
+ * ⚠️ Rate-limit: same-selector clicks fired within
+ * `CLICK_BY_SELECTOR_RATE_LIMIT_MS` of the previous one are rejected with
+ * `"Click prevented - too soon after previous click"`. Serialize click flows
+ * (await each call) to avoid this — parallel rapid clicks on the same target
+ * are intentionally suppressed to prevent double-submits in React handlers.
  */
 export const clickBySelector = defineCommand({
   name: 'electron_click_by_selector',
   description:
-    'Click an element by CSS selector. Returns the element tag/text on success. Replaces the deprecated click_button — pass selector="button" to keep that behavior.',
+    'Click an element by CSS selector. Returns the element tag/text on success. Note: same-selector clicks within ~1s are rate-limited and return "Click prevented - too soon after previous click" — serialize calls (await each) to avoid this. Replaces the deprecated click_button — pass selector="button" to keep that behavior.',
   schema,
   operationType: 'command',
   async execute(args, target) {
@@ -45,7 +52,7 @@ export const clickBySelector = defineCommand({
             }
 
             const clickKey = 'mcp_selector_click_' + btoa(${escapedSelector}).slice(0, 10);
-            if (window[clickKey] && Date.now() - window[clickKey] < 1000) {
+            if (window[clickKey] && Date.now() - window[clickKey] < ${CLICK_BY_SELECTOR_RATE_LIMIT_MS}) {
               return 'Click prevented - too soon after previous click';
             }
             window[clickKey] = Date.now();

--- a/src/commands/click/click-by-text.ts
+++ b/src/commands/click/click-by-text.ts
@@ -20,11 +20,18 @@ const schema = z.object({
  *
  * Caveat: short strings can false-positive on multiple candidates — see
  * GitHub issue #3. Phase 4 (T25-T28) will offer CDP-level alternatives.
+ *
+ * ⚠️ Rate-limit: same-element clicks fired within
+ * `CLICK_BY_TEXT_RATE_LIMIT_MS` of the previous one throw
+ * `"Element click prevented - too soon after previous click"`. The window is
+ * deliberately longer than the selector variant because text scoring +
+ * `scrollIntoView({ behavior: 'smooth' })` can legitimately take ~1s.
+ * Serialize click flows (await each call) to avoid this.
  */
 export const clickByText = defineCommand({
   name: 'electron_click_by_text',
   description:
-    'Click an element by visible text, aria-label, or title. Best for buttons/links. Returns confidence score on match.',
+    'Click an element by visible text, aria-label, or title. Best for buttons/links. Returns confidence score on match. Note: same-element clicks within ~2s are rate-limited and throw "Element click prevented - too soon after previous click" — serialize calls (await each) to avoid this.',
   schema,
   operationType: 'command',
   async execute(args, target) {

--- a/src/commands/click/click-by-text.ts
+++ b/src/commands/click/click-by-text.ts
@@ -22,16 +22,17 @@ const schema = z.object({
  * GitHub issue #3. Phase 4 (T25-T28) will offer CDP-level alternatives.
  *
  * ⚠️ Rate-limit: same-element clicks fired within
- * `CLICK_BY_TEXT_RATE_LIMIT_MS` of the previous one throw
- * `"Element click prevented - too soon after previous click"`. The window is
- * deliberately longer than the selector variant because text scoring +
- * `scrollIntoView({ behavior: 'smooth' })` can legitimately take ~1s.
- * Serialize click flows (await each call) to avoid this.
+ * `CLICK_BY_TEXT_RATE_LIMIT_MS` of the previous one return an error string
+ * containing `"Element click prevented - too soon after previous click"`
+ * (the underlying `throw` is caught and surfaced as a returned failure
+ * message). The window is deliberately longer than the selector variant
+ * because text scoring + `scrollIntoView({ behavior: 'smooth' })` can
+ * legitimately take ~1s. Serialize click flows (await each call) to avoid this.
  */
 export const clickByText = defineCommand({
   name: 'electron_click_by_text',
   description:
-    'Click an element by visible text, aria-label, or title. Best for buttons/links. Returns confidence score on match. Note: same-element clicks within ~2s are rate-limited and throw "Element click prevented - too soon after previous click" — serialize calls (await each) to avoid this.',
+    'Click an element by visible text, aria-label, or title. Best for buttons/links. Returns confidence score on match. Note: same-element clicks within ~2s are rate-limited and return an error containing "Element click prevented - too soon after previous click" — serialize calls (await each) to avoid this.',
   schema,
   operationType: 'command',
   async execute(args, target) {

--- a/src/commands/keyboard/press-key.ts
+++ b/src/commands/keyboard/press-key.ts
@@ -73,11 +73,27 @@ const MODIFIER_BIT: Readonly<Record<'Alt' | 'Ctrl' | 'Meta' | 'Shift', number>> 
  * `electron_send_keyboard_shortcut`, which uses synthetic events and is
  * cheaper. Use this when you need a key event the renderer treats as real
  * keyboard input.
+ *
+ * ⚠️ macOS OS-level text-editing shortcuts are NOT executed:
+ * `Cmd+A` (selectAll), `Cmd+C` / `Cmd+V` / `Cmd+X` (clipboard),
+ * `Cmd+Z` / `Cmd+Shift+Z` (undo/redo), and Electron `role: 'selectAll'`
+ * style menu items. CDP `Input.dispatchKeyEvent` only feeds a synthetic
+ * KeyboardEvent into the renderer; the OS keybinding layer that handles
+ * these shortcuts is bypassed. Playwright shares the same constraint.
+ *
+ * Workarounds:
+ * - select all text in an input/textarea:
+ *   `electron_eval` running `document.querySelector('...').select()` or
+ *   `el.setSelectionRange(0, el.value.length)`.
+ * - clipboard ops: `electron_eval` with the `navigator.clipboard.*` API.
+ * - app-level hotkeys (registered as `mousetrap`/`keydown` listeners on
+ *   `document`): prefer `electron_send_keyboard_shortcut` (synthetic event,
+ *   cheaper, and what app code expects).
  */
 export const pressKey = defineCommand({
   name: 'electron_press_key',
   description:
-    'Press a single key with optional modifiers via CDP. Use this for real keyboard input (cursor moves, IME) — for app hotkeys prefer electron_send_keyboard_shortcut.',
+    'Press a single key with optional modifiers via CDP. Use this for real keyboard input (cursor moves, IME) — for app hotkeys prefer electron_send_keyboard_shortcut. Note: macOS OS-level shortcuts (Cmd+A, Cmd+C/V/X, Cmd+Z) are bypassed by CDP synthetic events; use electron_eval (.select() / navigator.clipboard.*) instead.',
   schema,
   operationType: 'command',
   async execute(args, target) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,3 +20,18 @@ export const CDP_PORT_SCAN_END = 9230;
 
 /** Internal sentinel range for pool-managed CDP message IDs. Pool starts here. */
 export const CDP_POOL_MESSAGE_ID_START = 1;
+
+/**
+ * Rate-limit window for `electron_click_by_selector`. Same selector clicks
+ * within this window return "Click prevented - too soon after previous click"
+ * to suppress accidental double-firing in React event handlers.
+ */
+export const CLICK_BY_SELECTOR_RATE_LIMIT_MS = 1000;
+
+/**
+ * Rate-limit window for `electron_click_by_text` (renderer-side debounce in
+ * `generateClickByTextCommand`). Longer than the selector variant because
+ * text scoring + scrollIntoView animations can legitimately take ~1s, and
+ * the previous threshold (2000ms) was tuned empirically for React forms.
+ */
+export const CLICK_BY_TEXT_RATE_LIMIT_MS = 2000;

--- a/src/utils/electron-commands.ts
+++ b/src/utils/electron-commands.ts
@@ -2,6 +2,7 @@
  * Enhanced Electron interaction commands for React-based applications
  * Addresses common issues with form interactions, event handling, and state management
  */
+import { CLICK_BY_TEXT_RATE_LIMIT_MS } from '../constants';
 
 /**
  * Securely escape text input for JavaScript code generation
@@ -463,8 +464,11 @@ export function generateClickByTextCommand(text: string): string {
         const elementId = element.id || element.className || element.textContent?.slice(0, 20) || 'element';
         const clickKey = 'mcp_click_text_' + btoa(elementId).slice(0, 10);
         
-        // Check if this element was recently clicked
-        if (window[clickKey] && Date.now() - window[clickKey] < 2000) {
+        // Check if this element was recently clicked.
+        // Threshold is sourced from CLICK_BY_TEXT_RATE_LIMIT_MS in src/constants.ts
+        // (interpolated below) so the renderer-side debounce stays in sync with
+        // the value documented in the tool description.
+        if (window[clickKey] && Date.now() - window[clickKey] < ${CLICK_BY_TEXT_RATE_LIMIT_MS}) {
           throw new Error('Element click prevented - too soon after previous click');
         }
         


### PR DESCRIPTION
## Summary

`v2.0.0-rc.2` 出荷後の RC3 に向けたドキュメント整備 PR。`release` prefix を含まないため `release.yml` は trigger されず、本 PR の merge 自体は npm publish を起こしません (rc.3 の Critical 修正 PR と分離)。

### Issue #12 — `electron_press_key` macOS Cmd+A 等の制約明記

- TSDoc + tool description に **「macOS OS-level text-editing shortcut (`Cmd+A` / `Cmd+C` / `Cmd+V` / `Cmd+X` / `Cmd+Z`) は CDP `Input.dispatchKeyEvent` の synthetic event では bypass される」** 旨を追記
- 代替手段 (`electron_eval` で `el.select()` / `setSelectionRange` / `navigator.clipboard.*`、`electron_send_keyboard_shortcut`) を併記
- README Troubleshooting 表に対応行を追加

### Issue #19 — click 系ツールの rate-limit を docs + 定数化

- `click_by_selector` の `1000ms` debounce → `CLICK_BY_SELECTOR_RATE_LIMIT_MS` (`src/constants.ts`) に切り出し
- `click_by_text` の `2000ms` debounce → `CLICK_BY_TEXT_RATE_LIMIT_MS` に切り出し
- 両 tool description + TSDoc に rate-limit 値とエラー文言・回避策 (`await` 直列化) を明記
- README Troubleshooting 表の `"Click prevented - too soon"` 行を「なぜ起きるか + 解決策」に拡充

### CLAUDE.md は `.gitignore` のため対象外

Issue #19 ask の「`CLAUDE.md` の "Electron Command Priority" セクションに rate-limit 注意を追記」は、本 repo の `.gitignore:166` で `CLAUDE.md` 自体が ignored のため、本 PR の diff には含めていません。ローカルでは反映済 — 共有が必要なら別途 `.gitignore` の除外を検討してください。

## Files changed

| File | Change |
|------|--------|
| `src/constants.ts` | `CLICK_BY_SELECTOR_RATE_LIMIT_MS` / `CLICK_BY_TEXT_RATE_LIMIT_MS` 追加 |
| `src/commands/keyboard/press-key.ts` | TSDoc + tool description: macOS shortcut 制約と代替手段 |
| `src/commands/click/click-by-selector.ts` | TSDoc + description + 定数 interpolation |
| `src/commands/click/click-by-text.ts` | TSDoc + description |
| `src/utils/electron-commands.ts` | `generateClickByTextCommand` で定数 interpolation |
| `README.md` | Troubleshooting 表 2 行 polish |

## Test plan

- [x] `npm run code:check` ✅
- [x] `npm run build` ✅
- [x] `npm test` (unit 115 件) ✅ — `electron-security-integration` の `beforeAll` timeout は main でも同様 (pre-existing)
- [ ] CodeRabbit review pass
- [ ] Smoke check: docs-only PR のため、`SECURITY_LEVEL=development npx tsx src/index.ts` で tools/list を取得し description が更新されているか目視確認

## Out of scope (RC3 別 PR)

Critical 4 件 (#11 / #15 / #16 / #18) は別 PR (`fix/v2.0.0-rc.3-critical-issues`) として bundle し、`release v2.0.0-rc.3:` prefix で merge → `release.yml` auto-trigger → npm `rc` dist-tag publish の流れ。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved troubleshooting guidance with clarified click rate-limiting thresholds (~1s for selector-based clicks, ~2s for text-based clicks) and recommendations to serialize click operations.
  * Added macOS-specific notes on keyboard shortcut limitations and suggested workarounds for select-all and clipboard operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->