### PR TITLE
release v2.0.0-rc.3: address Critical issues #11 #15 #16 #18

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -111,8 +111,22 @@ These four tools kept their names and schemas. No migration needed:
 
 - `get_electron_window_info`
 - `list_electron_windows`
-- `take_screenshot`
 - `read_electron_logs`
+
+> **v2.0.0-rc.3 update (#18)** — `take_screenshot` was renamed to
+> `electron_take_screenshot` and now accepts an optional `targetId` (CDP target
+> ID) so multi-app environments can disambiguate which Electron window to
+> capture. Precedence is `targetId` > `windowTitle` > first detected app —
+> the same precedence used by every other `electron_*` tool. Update calls:
+>
+> ```jsonc
+> // v2.0.0-rc.2 and earlier
+> { "tool": "take_screenshot", "args": { "windowTitle": "QA Fixture" } }
+>
+> // v2.0.0-rc.3+
+> { "tool": "electron_take_screenshot",
+>   "args": { "targetId": "<from electron_list_windows>" } }
+> ```
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@laststance/electron-mcp-server",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "description": "MCP server for Electron application automation and management. See MCP_USAGE_GUIDE.md for proper argument structure examples.",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/eval/eval.ts
+++ b/src/commands/eval/eval.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { EXECUTE_IN_ELECTRON_RESULT_PREFIX } from '../../constants';
 import { executeInElectron } from '../../utils/electron-connection';
 import { windowTargetFields } from '../shared/window-target';
 import { defineCommand } from '../types';
@@ -100,7 +101,11 @@ export const evalCommand = defineCommand({
             return { success: false, error: 'Command returned false - action likely failed', result: false };
           }
 
-          return { success: true, error: null, result: result };
+          // Normalize undefined to null so JSON.stringify keeps the 'result' key.
+          // Without this, JSON.stringify({ result: undefined }) → '{}' and the
+          // handler can't distinguish "missing" from "explicitly undefined".
+          // Reported in #11 (electron_eval response omits 'result' on undefined).
+          return { success: true, error: null, result: typeof result === 'undefined' ? null : result };
         } catch (error) {
           return {
             success: false,
@@ -114,19 +119,27 @@ export const evalCommand = defineCommand({
 
     const rawResult = await executeInElectron(javascriptCode, target);
 
+    // executeInElectron wraps every successful return in `✅ Result: <value>`
+    // (see src/utils/electron-connection.ts:206-215). Our IIFE returns a JSON
+    // object, so the prefix needs to be stripped before JSON.parse — otherwise
+    // parsing fails and the fallback path below double-wraps to
+    // `✅ Result: ✅ Result: { ... }` (#11).
+    const jsonPayload = rawResult.startsWith(EXECUTE_IN_ELECTRON_RESULT_PREFIX)
+      ? rawResult.slice(EXECUTE_IN_ELECTRON_RESULT_PREFIX.length)
+      : rawResult;
+
     try {
-      const parsed = JSON.parse(rawResult) as StructuredEvalResult;
+      const parsed = JSON.parse(jsonPayload) as StructuredEvalResult;
       if (parsed && typeof parsed === 'object' && 'success' in parsed) {
         if (!parsed.success) {
           return `❌ Command failed: ${parsed.error}${
             parsed.stack ? '\nStack: ' + parsed.stack : ''
           }`;
         }
-        return `✅ Command successful${
-          parsed.result !== null && parsed.result !== undefined
-            ? ': ' + JSON.stringify(parsed.result)
-            : ''
-        }`;
+        // parsed.result is now always present (null when underlying value was
+        // undefined, see IIFE comment). Emit `result: null` explicitly so the
+        // caller can rely on the key existing.
+        return `✅ Command successful: ${JSON.stringify(parsed.result ?? null)}`;
       }
     } catch {
       // Fall through to legacy formatting below.
@@ -136,6 +149,10 @@ export const evalCommand = defineCommand({
       return `⚠️ Command executed but returned ${rawResult || 'empty'} - this may indicate the element wasn't found or the action failed`;
     }
 
-    return `✅ Result: ${rawResult}`;
+    // Guard against double-prefixing if rawResult already starts with the
+    // executeInElectron prefix (we couldn't parse the inner payload as JSON).
+    return rawResult.startsWith(EXECUTE_IN_ELECTRON_RESULT_PREFIX)
+      ? rawResult
+      : `${EXECUTE_IN_ELECTRON_RESULT_PREFIX}${rawResult}`;
   },
 });

--- a/src/commands/screenshot/index.ts
+++ b/src/commands/screenshot/index.ts
@@ -1,3 +1,3 @@
-// Reserved for future migration of the existing top-level take_screenshot tool.
-// Currently take_screenshot lives in src/screenshot.ts and stays there in Phase 1.
+// Reserved for future migration of the existing top-level electron_take_screenshot tool.
+// Currently electron_take_screenshot lives in src/screenshot.ts and stays there in Phase 1.
 export {};

--- a/src/commands/scroll/get-scroll-position.ts
+++ b/src/commands/scroll/get-scroll-position.ts
@@ -38,7 +38,7 @@ export const getScrollPosition = defineCommand({
   operationType: 'query',
   async execute(args, target) {
     if (args.selector !== undefined && containsDangerousContent(args.selector)) {
-      return 'Invalid selector: contains dangerous content';
+      return JSON.stringify({ error: 'Invalid selector: contains dangerous content' });
     }
 
     const selectorLiteral = args.selector === undefined ? 'null' : escapeJsString(args.selector);
@@ -74,7 +74,7 @@ export const getScrollPosition = defineCommand({
             maxScrollY: maxScrollY
           });
         } catch (e) {
-          return 'Error reading scroll position: ' + e.message;
+          return JSON.stringify({ error: 'Error reading scroll position: ' + e.message });
         }
       })();
     `;

--- a/src/commands/scroll/get-scroll-position.ts
+++ b/src/commands/scroll/get-scroll-position.ts
@@ -1,37 +1,75 @@
 import { z } from 'zod';
 import { executeInElectron } from '../../utils/electron-connection';
+import { containsDangerousContent, escapeJsString } from '../shared/escaping';
 import { windowTargetFields } from '../shared/window-target';
 import { defineCommand } from '../types';
 
 const schema = z.object({
   ...windowTargetFields,
+  selector: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      'Optional CSS selector. When provided, returns scroll metrics for that element (overflow:auto / overflow:scroll viewport). Omit to read window scroll.',
+    ),
 });
 
 /**
- * Read the current window scroll position and document scroll extents.
+ * Read scroll position and extents for either the document or a specific
+ * scrollable element.
  *
- * Returns JSON `{ scrollX, scrollY, maxScrollX, maxScrollY }` so callers can
- * detect "scrolled to bottom" via `scrollY >= maxScrollY`.
+ * - Without `selector`: returns `window.scrollX/scrollY` and document
+ *   `documentElement.scrollWidth/Height - window.innerWidth/Height` (clamped
+ *   to 0 for non-scrollable axes).
+ * - With `selector`: returns `el.scrollLeft/scrollTop` and
+ *   `el.scrollWidth/Height - el.clientWidth/Height` so callers can detect
+ *   inner-viewport "scrolled to bottom" without falling back to `eval`.
  *
- * `maxScrollX/Y` are computed as `documentElement.scrollWidth/Height -
- * window.innerWidth/Height`, clamped to 0 for non-scrollable axes.
+ * Mirrors the precedence already accepted by `electron_scroll_to_element` /
+ * `electron_scroll_by_pixels` (which take an optional selector) — fixes #16
+ * where the selector argument was silently stripped.
  */
 export const getScrollPosition = defineCommand({
   name: 'electron_get_scroll_position',
   description:
-    'Read window.scrollX/scrollY plus max scroll extents. Returns JSON {scrollX, scrollY, maxScrollX, maxScrollY}.',
+    'Read scroll metrics for the window (default) or an element matching `selector`. Returns JSON {scrollX, scrollY, maxScrollX, maxScrollY}; element variants source the values from el.scrollLeft / scrollTop / scrollWidth - clientWidth / scrollHeight - clientHeight.',
   schema,
   operationType: 'query',
-  async execute(_args, target) {
+  async execute(args, target) {
+    if (args.selector !== undefined && containsDangerousContent(args.selector)) {
+      return 'Invalid selector: contains dangerous content';
+    }
+
+    const selectorLiteral = args.selector === undefined ? 'null' : escapeJsString(args.selector);
+
     const javascriptCode = `
       (function() {
         try {
-          const root = document.documentElement;
-          const maxScrollX = Math.max(0, root.scrollWidth - window.innerWidth);
-          const maxScrollY = Math.max(0, root.scrollHeight - window.innerHeight);
+          const selector = ${selectorLiteral};
+          if (selector === null) {
+            const root = document.documentElement;
+            const maxScrollX = Math.max(0, root.scrollWidth - window.innerWidth);
+            const maxScrollY = Math.max(0, root.scrollHeight - window.innerHeight);
+            return JSON.stringify({
+              scrollX: window.scrollX,
+              scrollY: window.scrollY,
+              maxScrollX: maxScrollX,
+              maxScrollY: maxScrollY
+            });
+          }
+          const element = document.querySelector(selector);
+          if (!element) {
+            return JSON.stringify({ error: 'Element not found: ' + selector });
+          }
+          // Use scrollLeft/scrollTop for inner viewport; subtract clientWidth/Height
+          // (not innerWidth/Height) so the result reflects the visible area of the
+          // scrollable container itself, not the document viewport.
+          const maxScrollX = Math.max(0, element.scrollWidth - element.clientWidth);
+          const maxScrollY = Math.max(0, element.scrollHeight - element.clientHeight);
           return JSON.stringify({
-            scrollX: window.scrollX,
-            scrollY: window.scrollY,
+            scrollX: element.scrollLeft,
+            scrollY: element.scrollTop,
             maxScrollX: maxScrollX,
             maxScrollY: maxScrollY
           });

--- a/src/commands/storage/clear-storage.ts
+++ b/src/commands/storage/clear-storage.ts
@@ -3,13 +3,35 @@ import { executeInElectron } from '../../utils/electron-connection';
 import { windowTargetFields } from '../shared/window-target';
 import { defineCommand } from '../types';
 
+/**
+ * Some MCP clients serialize array fields as a JSON-encoded string when the
+ * underlying transport flattens arguments (observed in #15 — `Expected array,
+ * received string at scopes`). Accept both shapes via `z.preprocess`: parse a
+ * string that looks like a JSON array, otherwise pass the value through
+ * untouched and let the inner schema flag genuine type errors.
+ *
+ * @example
+ *   coerceScopes('["local","session"]') // => ['local', 'session']
+ *   coerceScopes(['local', 'cookies'])  // => ['local', 'cookies'] (untouched)
+ *   coerceScopes('local')               // => 'local' (will fail z.array check)
+ */
+function coerceScopes(rawScopes: unknown): unknown {
+  if (typeof rawScopes !== 'string') return rawScopes;
+  const trimmed = rawScopes.trim();
+  if (!trimmed.startsWith('[')) return rawScopes;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return rawScopes;
+  }
+}
+
 const schema = z.object({
   ...windowTargetFields,
   scopes: z
-    .array(z.enum(['local', 'session', 'cookies']))
-    .min(1)
+    .preprocess(coerceScopes, z.array(z.enum(['local', 'session', 'cookies'])).min(1))
     .describe(
-      'Storage scopes to clear. Cookies are cleared for the current document.cookie origin only.',
+      'Storage scopes to clear. Cookies are cleared for the current document.cookie origin only. Accepts a JSON-encoded array string for clients that serialize arrays as strings.',
     ),
 });
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,3 +20,12 @@ export const CDP_PORT_SCAN_END = 9230;
 
 /** Internal sentinel range for pool-managed CDP message IDs. Pool starts here. */
 export const CDP_POOL_MESSAGE_ID_START = 1;
+
+/**
+ * Prefix that `executeInElectron` (src/utils/electron-connection.ts) prepends
+ * to every successful Runtime.evaluate result string. Centralized here so
+ * `electron_eval` can detect the wrapper and avoid double-prefixing
+ * (`✅ Result: ✅ Result: ...`) when its IIFE return is fed back through the
+ * same helper. See #11 for the original double-prefix bug.
+ */
+export const EXECUTE_IN_ELECTRON_RESULT_PREFIX = '✅ Result: ';

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -66,7 +66,7 @@ export async function handleToolCall(request: z.infer<typeof CallToolRequestSche
 
       case ToolName.TAKE_SCREENSHOT: {
         const securityResult = await securityManager.executeSecurely({
-          command: 'take_screenshot',
+          command: 'electron_take_screenshot',
           args,
           sourceIP,
           userAgent,
@@ -79,8 +79,8 @@ export async function handleToolCall(request: z.infer<typeof CallToolRequestSche
             isError: true,
           };
         }
-        const { outputPath, windowTitle } = TakeScreenshotSchema.parse(args);
-        const result = await takeScreenshot(outputPath, windowTitle);
+        const { outputPath, windowTitle, targetId } = TakeScreenshotSchema.parse(args);
+        const result = await takeScreenshot({ outputPath, windowTitle, targetId });
 
         const content: any[] = [];
         if (result.filePath) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -8,6 +8,12 @@ export const TakeScreenshotSchema = z.object({
     .optional()
     .describe('Path to save the screenshot (optional, defaults to temp directory)'),
   windowTitle: z.string().optional().describe('Specific window title to screenshot (optional)'),
+  targetId: z
+    .string()
+    .optional()
+    .describe(
+      'CDP target ID (from electron_list_windows). Takes precedence over windowTitle when both are provided. Required for unambiguous targeting when multiple Electron apps run on different debugging ports.',
+    ),
 });
 
 export const ReadElectronLogsSchema = z.object({

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -146,16 +146,37 @@ function encryptScreenshotData(buffer: Buffer): EncryptedScreenshot {
   }
 }
 
-// Helper function to take screenshot using only Playwright CDP (Chrome DevTools Protocol)
-export async function takeScreenshot(
-  outputPath?: string,
-  windowTitle?: string,
-): Promise<{
+/**
+ * Capture a PNG screenshot of an Electron app via Playwright over CDP.
+ *
+ * Targeting precedence (matches `electron_*` tools that share `targetId` /
+ * `windowTitle` — see `src/commands/shared/window-target.ts`):
+ *   1. `targetId` — exact CDP target match across every running app.
+ *   2. `windowTitle` — first app with a target whose title matches (case-
+ *      insensitive substring).
+ *   3. neither — first app returned by `scanForElectronApps`.
+ *
+ * Without `targetId`, parallel Electron apps (skills-desktop on :9222 and
+ * qa-fixture on :9223, for example) can collide on `apps[0]` and silently
+ * return the wrong app's screenshot — that's the bug fixed in #18.
+ *
+ * @param options.outputPath  Optional path to save the PNG (and an
+ *   `.encrypted` companion). When omitted, returns base64 only.
+ * @param options.windowTitle Case-insensitive substring matched against page
+ *   titles. Used both to pick the app and to pick the right page within it.
+ * @param options.targetId    Exact CDP target ID. Wins over `windowTitle`.
+ */
+export async function takeScreenshot(options: {
+  outputPath?: string;
+  windowTitle?: string;
+  targetId?: string;
+}): Promise<{
   filePath?: string;
   base64: string;
   data: string;
   error?: string;
 }> {
+  const { outputPath, windowTitle, targetId } = options;
   // Validate output path for security
   if (outputPath && !validateScreenshotPath(outputPath)) {
     throw new Error(
@@ -167,6 +188,7 @@ export async function takeScreenshot(
   logger.info('📸 Taking screenshot of Electron application', {
     outputPath,
     windowTitle,
+    targetId,
     timestamp: new Date().toISOString(),
   });
   try {
@@ -176,9 +198,17 @@ export async function takeScreenshot(
       throw new Error('No running Electron applications found with remote debugging enabled');
     }
 
-    // Use the first app found (or find by title if specified)
+    // Pick the app: targetId > windowTitle > first app.
     let targetApp = apps[0];
-    if (windowTitle) {
+    if (targetId) {
+      const idMatchedApp = apps.find((app) => app.targets.some((target) => target.id === targetId));
+      if (!idMatchedApp) {
+        throw new Error(
+          `No Electron app found with targetId=${targetId}. Use electron_list_windows to enumerate available targets.`,
+        );
+      }
+      targetApp = idMatchedApp;
+    } else if (windowTitle) {
       const namedApp = apps.find((app) =>
         app.targets.some((target) =>
           target.title?.toLowerCase().includes(windowTitle.toLowerCase()),
@@ -206,7 +236,13 @@ export async function takeScreenshot(
       throw new Error('No pages found in the browser context');
     }
 
-    // Find the main application page (skip DevTools pages)
+    // Find the main application page (skip DevTools pages).
+    // Page selection mirrors the app-level precedence:
+    //   targetId — match Playwright page URL containing the target id (CDP
+    //     exposes target id only on browser-level Targets; on Page level we
+    //     fall back to URL/title heuristics).
+    //   windowTitle — first non-DevTools page whose title matches.
+    //   neither — first non-DevTools page.
     let targetPage = pages[0];
     for (const page of pages) {
       const url = page.url();
@@ -219,8 +255,12 @@ export async function takeScreenshot(
         title &&
         !title.includes('DevTools')
       ) {
-        // If windowTitle is specified, try to match it
-        if (windowTitle && title.toLowerCase().includes(windowTitle.toLowerCase())) {
+        if (targetId) {
+          if (url.includes(targetId)) {
+            targetPage = page;
+            break;
+          }
+        } else if (windowTitle && title.toLowerCase().includes(windowTitle.toLowerCase())) {
           targetPage = page;
           break;
         } else if (!windowTitle) {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -9,14 +9,21 @@ import {
 import { allCommands } from './commands';
 
 /**
- * Names of the static (non-`electron_*`) MCP tools.
+ * Names of the static (non-per-command) MCP tools.
  *
  * v2.0.0 removed `SEND_COMMAND_TO_ELECTRON` and replaced it with one tool per
  * UI command (registered dynamically from `allCommands`). Static tools handle
  * cross-cutting concerns that aren't tied to a single CDP target.
+ *
+ * Naming: `take_screenshot` was renamed to `electron_take_screenshot` in
+ * v2.0.0-rc.3 (#18) so it accepts the same `targetId` precedence as every
+ * other CDP-targeted tool. The other static names (`read_electron_logs`,
+ * `get_electron_window_info`, `list_electron_windows`) already encode
+ * "electron" in the noun and are intentionally left as-is for now —
+ * harmonizing them is tracked separately.
  */
 export enum ToolName {
-  TAKE_SCREENSHOT = 'take_screenshot',
+  TAKE_SCREENSHOT = 'electron_take_screenshot',
   READ_ELECTRON_LOGS = 'read_electron_logs',
   GET_ELECTRON_WINDOW_INFO = 'get_electron_window_info',
   LIST_ELECTRON_WINDOWS = 'list_electron_windows',
@@ -43,7 +50,7 @@ const staticTools = [
   {
     name: ToolName.TAKE_SCREENSHOT,
     description:
-      'Take a screenshot of any running Electron application window. Returns base64 image data for AI analysis. No files created unless outputPath is specified.',
+      'Take a screenshot of any running Electron application window. Returns base64 image data for AI analysis. No files created unless outputPath is specified. Pass `targetId` (from electron_list_windows) for unambiguous targeting when multiple Electron apps run on different debugging ports — `targetId` takes precedence over `windowTitle`.',
     inputSchema: zodToJsonSchema(TakeScreenshotSchema) as ToolInput,
   },
   {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -50,7 +50,7 @@ const staticTools = [
   {
     name: ToolName.TAKE_SCREENSHOT,
     description:
-      'Take a screenshot of any running Electron application window. Returns base64 image data for AI analysis. No files created unless outputPath is specified. Pass `targetId` (from electron_list_windows) for unambiguous targeting when multiple Electron apps run on different debugging ports — `targetId` takes precedence over `windowTitle`.',
+      'Take a screenshot of any running Electron application window. Returns base64 image data for AI analysis. No files created unless outputPath is specified. Pass `targetId` (from list_electron_windows) for unambiguous targeting when multiple Electron apps run on different debugging ports — `targetId` takes precedence over `windowTitle`.',
     inputSchema: zodToJsonSchema(TakeScreenshotSchema) as ToolInput,
   },
   {

--- a/src/utils/electron-connection.ts
+++ b/src/utils/electron-connection.ts
@@ -1,4 +1,5 @@
 import WebSocket from 'ws';
+import { EXECUTE_IN_ELECTRON_RESULT_PREFIX } from '../constants';
 import { CdpConnectionPool, type RuntimeEvaluateResultPayload } from './cdp-pool';
 import { scanForElectronApps, findMainTarget } from './electron-discovery';
 import { logger } from './logger';
@@ -203,16 +204,16 @@ function formatEvaluateResult(payload: RuntimeEvaluateResultPayload): string {
       return `✅ Command executed: ${String(result.value)}`;
     case 'number':
     case 'boolean':
-      return `✅ Result: ${String(result.value)}`;
+      return `${EXECUTE_IN_ELECTRON_RESULT_PREFIX}${String(result.value)}`;
     case 'undefined':
       return `✅ Command executed successfully`;
     case 'object': {
-      if (result.value === null) return `✅ Result: null`;
-      if (result.value === undefined) return `✅ Result: undefined`;
+      if (result.value === null) return `${EXECUTE_IN_ELECTRON_RESULT_PREFIX}null`;
+      if (result.value === undefined) return `${EXECUTE_IN_ELECTRON_RESULT_PREFIX}undefined`;
       try {
-        return `✅ Result: ${JSON.stringify(result.value, null, 2)}`;
+        return `${EXECUTE_IN_ELECTRON_RESULT_PREFIX}${JSON.stringify(result.value, null, 2)}`;
       } catch {
-        return `✅ Result: [Object - could not serialize: ${
+        return `${EXECUTE_IN_ELECTRON_RESULT_PREFIX}[Object - could not serialize: ${
           result.className || result.objectId || 'unknown'
         }]`;
       }

--- a/tests/unit/security-manager.test.ts
+++ b/tests/unit/security-manager.test.ts
@@ -19,7 +19,12 @@ describe('SecurityManager Unit Tests', () => {
     });
 
     it('should not sandbox simple command names', () => {
-      const simpleCommands = ['get_window_info', 'take_screenshot', 'get_title', 'get_url'];
+      const simpleCommands = [
+        'get_window_info',
+        'electron_take_screenshot',
+        'get_title',
+        'get_url',
+      ];
 
       simpleCommands.forEach((command) => {
         const result = securityManager.shouldSandboxCommand(command);


### PR DESCRIPTION
## Summary

Bundles the four Critical issues remaining after rc.2 into a single rc.3 release.

| Issue | Tool | Fix |
|-------|------|-----|
| #11 | `electron_eval` | Strip `✅ Result: ` prefix before `JSON.parse` and normalize `undefined → null` in the IIFE. Eliminates the double-prefixed `"✅ Command successful: ✅ Result: ..."` output. |
| #15 | `electron_clear_storage` | Accept JSON-encoded array string for `scopes` via `z.preprocess`. Some MCP clients flatten array args into strings; validation previously rejected them with `Expected array, received string`. |
| #16 | `electron_get_scroll_position` | Add optional `selector`. The IIFE now branches on window scroll (default) vs element scroll. Without this, callers had no way to query an inner scroll container. |
| #18 | `take_screenshot` → `electron_take_screenshot` | Pure rename + new optional `targetId`. Precedence is now `targetId` > `windowTitle` > first detected — same as every other `electron_*` tool. |

Centralizes the `"✅ Result: "` literal in `src/constants.ts` as `EXECUTE_IN_ELECTRON_RESULT_PREFIX` so `eval.ts` and `electron-connection.ts` share one source of truth.

`MIGRATION.md` includes an rc.3 update block under the static-tools section explaining the screenshot rename and `targetId` precedence.

## Test plan

- [x] `npm run code:check` — lint + prettier pass
- [x] `npm run build` — webpack production build succeeds
- [x] 115 unit tests pass (integration suite excluded due to pre-existing `beforeAll` 10s timeout on main, unrelated to this PR)
- [x] JSON-RPC `tools/list` confirms `electron_take_screenshot` is registered with `[outputPath, windowTitle, targetId]` properties
- [ ] Manual smoke check in `~/laststance/skills-desktop` after rc.3 publish:
  - [ ] `electron_eval` returns single-prefixed `✅ Command successful: <json>`
  - [ ] `electron_clear_storage` accepts both `["local","session"]` (string) and `['local','session']` (array)
  - [ ] `electron_get_scroll_position` with `selector` returns inner-container scroll
  - [ ] `electron_take_screenshot` with `targetId` from `electron_list_windows` captures the right window in a multi-window session

## Notes

- The other 3 unprefixed static tools (`get_electron_window_info`, `list_electron_windows`, `read_electron_logs`) intentionally keep their names — Issue #18 only asked for `take_screenshot`. Renaming those is separate scope.
- After squash-merge to `main`, the `release v2.0.0-rc.3` title will trigger `release.yml`, which auto-publishes to npm under the `rc` dist-tag via OIDC Trusted Publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Screenshot command now supports `targetId` for multi-window app targeting (takes precedence over `windowTitle`)
  * Scroll position command supports optional element selector targeting

* **Bug Fixes**
  * Eval command now properly returns null for undefined results
  * Storage clearing command improved to accept JSON-encoded array inputs

* **Chores**
  * Version bumped to v2.0.0-rc.3
  * Renamed screenshot command from `take_screenshot` to `electron_take_screenshot`

* **Documentation**
  * Migration guide updated to reflect new screenshot command naming and features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->