### PR TITLE
release v2.0.0: stable release after rc.3 QA verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ Thumbs.db
 
 # Claude Code
 CLAUDE.md
+.claude/goal.json
+.claude/goal-notes.md

--- a/README.md
+++ b/README.md
@@ -290,6 +290,34 @@ Add to your VS Code MCP settings:
 }
 ```
 
+### Claude Code (CLI)
+
+The fastest way to add this server to Claude Code is the `claude mcp add` command. Options come **before** the server name; the `--` separator marks where the spawn command begins.
+
+**Project-scoped (lives in `.mcp.json`, share via git):**
+
+```bash
+claude mcp add electron-mcp \
+  --env SECURITY_LEVEL=balanced \
+  -- npx -y @laststance/electron-mcp-server@latest
+```
+
+**User-scoped (available across every project on this machine):**
+
+```bash
+claude mcp add --scope user electron-mcp \
+  --env SECURITY_LEVEL=balanced \
+  -- npx -y @laststance/electron-mcp-server@latest
+```
+
+**Verify:**
+
+```bash
+claude mcp list
+```
+
+> 💡 On Windows, prefix the spawn command with `cmd /c` (e.g. `-- cmd /c npx -y @laststance/electron-mcp-server@latest`) so the npx shim resolves correctly.
+
 ### Cursor IDE Integration
 
 Cursor IDE supports MCP servers through its configuration file. Add to your Cursor MCP settings:
@@ -346,6 +374,29 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
   }
 }
 ```
+
+### OpenAI Codex CLI
+
+The Codex CLI registers MCP servers through `~/.codex/config.toml` (CLI and IDE extension share the same file).
+
+**One-liner (preferred):**
+
+```bash
+codex mcp add electron-mcp -- npx -y @laststance/electron-mcp-server@latest
+```
+
+**Or edit `~/.codex/config.toml` directly:**
+
+```toml
+[mcp_servers.electron-mcp]
+command = "npx"
+args = ["-y", "@laststance/electron-mcp-server@latest"]
+
+[mcp_servers.electron-mcp.env]
+SECURITY_LEVEL = "balanced"
+```
+
+Codex launches the server automatically on session start and exposes its `electron_*` tools next to the built-ins.
 
 ### Global Installation
 

--- a/claudedocs/qa_2026-05-02_v2.0.0-rc.3-results.md
+++ b/claudedocs/qa_2026-05-02_v2.0.0-rc.3-results.md
@@ -1,0 +1,50 @@
+# v2.0.0-rc.3 QA Round — Results
+
+**Date:** 2026-05-02
+**Target:** `playground/qa-fixture` (electron-vite app on CDP port 9223)
+**MCP server:** `src/index.ts` (rc.3 source) via `tsx`, `SECURITY_LEVEL=development`
+**Window targetId:** `49DBCFF5E7379EFF4FCE4A61BA1F2573`
+**Method:** stdio JSON-RPC 2.0 piped from prepared input files
+
+## Critical fix verification (Issues #11/#15/#16/#18)
+
+| Issue | Tool | Test | Result | Evidence (excerpt) |
+|-------|------|------|--------|---------------------|
+| **#11** double-prefix | `electron_eval` | `1 + 2` | ✅ PASS | `"✅ Command successful: 3"` (single prefix; pre-fix would double) |
+| **#15** clear-storage normalization | `electron_clear_storage` | `scopes:["local"]` | ✅ PASS | `"✅ Command executed: Cleared: local"` (clean string, not `[object Object]`) |
+| **#16** scroll-position selector arg | `electron_get_scroll_position` | `selector:"body"` | ✅ PASS | `"✅ Command executed: {\"scrollX\":0,\"scrollY\":0,\"maxScrollX\":0,\"maxScrollY\":0}"` (selector accepted, no validation error) |
+| **#18** screenshot target resolution | `electron_take_screenshot` | `targetId:<hash>` only | ✅ PASS | Returned `image/png` base64 (PNG magic header `iVBORw0KGgo...`) — `targetId` precedence honored |
+
+## Smoke tests by category (representative tools)
+
+| Category | Tool | Result | Evidence (excerpt) |
+|----------|------|--------|---------------------|
+| **Static — discovery** | `get_electron_window_info` | ✅ PASS | `automationReady:true`, port 9223, 1 electron target |
+| Static — discovery | `list_electron_windows` | ✅ PASS | `Available Electron windows (1): ... QA Fixture - Primary` |
+| Static — capture | `electron_take_screenshot` | ✅ PASS | base64 PNG returned in `content[1].data` |
+| **Query** | `electron_get_title` | ✅ PASS | `"QA Fixture - Primary"` |
+| Query | `electron_get_url` | ✅ PASS | `file:///.../#/` |
+| Query | `electron_get_body_text` | ✅ PASS | Full visible text including nav links |
+| Query | `electron_get_viewport_size` | ✅ PASS | `{width:1024,height:688,devicePixelRatio:2}` |
+| Query | `electron_find_elements` | ✅ PASS | 8 clickable elements + containers + metadata |
+| **Navigate** | `electron_navigate_to_hash` | ✅ PASS | `Navigated to hash: #/forms` |
+| **Wait** | `electron_wait_for_selector` | ✅ PASS | `Found: input[type=text] (waited 16ms)` after navigate |
+| **Click** | `electron_click_by_text` | ✅ PASS | `Successfully clicked element (score: 220): "Home"` |
+| **Scroll** | `electron_scroll_by_pixels` | ✅ PASS | Mechanism returns scroll delta JSON |
+| **Keyboard** | `electron_press_key` | ✅ PASS | `Pressed key: Tab` |
+| **Storage** | `electron_local_storage_set_item` | ✅ PASS | `Set localStorage: qa_seed` |
+| Storage | `electron_local_storage_get_item` | ✅ PASS | Returns stored value `hello` |
+| Storage | `electron_clear_storage` | ✅ PASS | `Cleared: local` |
+| **Eval** | `electron_eval` | ✅ PASS | See #11 row |
+
+**Total tools verified:** 18 (4 critical-fix + 14 smoke). All `electron_*` categories represented.
+
+## Findings
+
+1. **`src/index.ts:18` ships hardcoded `version: '1.5.1'`** in `serverInfo` — stale since v1.5.1. Bump to `2.0.0` during the version-bump step (criterion 3 of this goal).
+2. **JSON-RPC requests piped via stdin run concurrently** (not strictly sequential). Tests like `set → clear → get` need to be split into separate process invocations or use `awaitPromise` semantics. Not a regression — fundamental MCP stdio transport behavior.
+3. **No new bugs surfaced.** All four critical fixes from rc.3 (#11/#15/#16/#18) verified working end-to-end on a real Electron app.
+
+## Verdict
+
+✅ **rc.3 is ready for promotion to v2.0.0 stable.** No regressions, all critical fixes verified, broad tool coverage shown working.

--- a/claudedocs/qa_2026-05-02_v2.0.0-rc.3-results.md
+++ b/claudedocs/qa_2026-05-02_v2.0.0-rc.3-results.md
@@ -48,3 +48,7 @@
 ## Verdict
 
 ✅ **rc.3 is ready for promotion to v2.0.0 stable.** No regressions, all critical fixes verified, broad tool coverage shown working.
+
+---
+
+**Release approved 2026-05-02** — version bumped to 2.0.0 in package.json, src/index.ts serverInfo updated from stale `1.5.1` → `2.0.0`. Awaiting CodeRabbit pass + squash-merge.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@laststance/electron-mcp-server",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@laststance/electron-mcp-server",
-      "version": "2.0.0-rc.2",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@laststance/electron-mcp-server",
-  "version": "2.0.0-rc.3",
+  "version": "2.0.0",
   "description": "MCP server for Electron application automation and management. See MCP_USAGE_GUIDE.md for proper argument structure examples.",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ config({ quiet: true });
 const server = new Server(
   {
     name: 'electron-mcp-server',
-    version: '1.5.1',
+    version: '2.0.0',
   },
   {
     capabilities: {


### PR DESCRIPTION
## Summary

Promotes `2.0.0-rc.3` → `2.0.0` stable. All four critical fixes from the rc cycle (#11/#15/#16/#18) verified working end-to-end on `playground/qa-fixture` (see `claudedocs/qa_2026-05-02_v2.0.0-rc.3-results.md` for the full evidence table — 4 critical-fix + 14 smoke tools, all PASS).

### Why now
- rc.3 has been live on the npm `rc` dist-tag for one day; no new Critical issues reported and the user has installed/restarted against rc.3 successfully.
- `latest` dist-tag is still pinned to `1.7.1`, so a fresh `npm install @laststance/electron-mcp-server` keeps pulling the v1 baseline. Promoting now gives AI-agent users the v2 toolset (one MCP tool per `electron_*` command, fixed eval/scroll/screenshot/storage paths) by default.
- BC vs v1 is intentional and already documented in tool descriptions (`tools/list` returns the v2 names + schemas), and no migration guide is required per the user's release policy — primary consumers are AI agents that discover tools dynamically.

### Changes
- **`package.json` + `package-lock.json`**: `2.0.0-rc.3` → `2.0.0`
- **`src/index.ts:18`**: hardcoded `serverInfo.version` `'1.5.1'` → `'2.0.0'` (was stale since v1.5.1, surfaced during this QA round)
- **`README.md`**: add `claude mcp add` snippet (project-scope + user-scope variants, with Windows `cmd /c` note) and `codex mcp add` snippet (CLI + TOML form). Existing VS Code / Cursor / Claude Desktop / Global sections kept as-is.
- **`claudedocs/qa_2026-05-02_v2.0.0-rc.3-results.md`**: new — per-tool QA evidence for the rc.3 → v2.0.0 promotion.

### Release pipeline
On squash-merge with the title preserved, `.github/workflows/release.yml` matches `release v\d+\.\d+\.\d+` and publishes to npm via OIDC Trusted Publishing. No manual `npm publish` needed.

## Test plan

- [x] All four critical fixes verified on `qa-fixture` via JSON-RPC against `src/index.ts` (rc.3 source)
- [x] 14 representative `electron_*` tools smoke-tested (query / navigate / wait / click / scroll / keyboard / storage / eval)
- [x] `npm run code:check` passes (lint + format)
- [x] `npm run build` succeeds (webpack production)
- [x] `jq -r .version` confirms `2.0.0` in both package.json and package-lock.json
- [ ] CodeRabbit Pro review — pending push
- [ ] release.yml workflow run after squash-merge — pending merge
- [ ] `npm view @laststance/electron-mcp-server@2.0.0 version` returns `2.0.0` — pending publish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added setup guides for integrating with Claude Code CLI and OpenAI Codex CLI, with examples and platform notes.
  * Published RC.3 QA verification report summarizing end-to-end tests, smoke tests across tools, findings, and release approval.

* **Chores**
  * Released stable version 2.0.0.
  * Added ignore entries for generated Claude artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->