### PR TITLE
release v2.0.1: React 19 detection (#20), click_by_text scoring (#3), eval serialization (#10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@laststance/electron-mcp-server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "MCP server for Electron application automation and management. See MCP_USAGE_GUIDE.md for proper argument structure examples.",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/eval/eval.ts
+++ b/src/commands/eval/eval.ts
@@ -60,36 +60,13 @@ export const evalCommand = defineCommand({
   schema,
   operationType: 'eval',
   async execute(args, target) {
-    const codeHash = Buffer.from(args.code).toString('base64').slice(0, 10);
-    const isStateTest =
-      args.code.includes('window.testState') ||
-      args.code.includes('persistent-test-value') ||
-      args.code.includes('window.testValue');
-
     const javascriptCode = `
       (function() {
         try {
-          const codeHash = '${codeHash}';
-          const isStateTest = ${isStateTest};
           const rawCode = ${JSON.stringify(args.code)};
-
-          if (!isStateTest && window._mcpExecuting && window._mcpExecuting[codeHash]) {
-            return { success: false, error: 'Code already executing', result: null };
-          }
-
-          window._mcpExecuting = window._mcpExecuting || {};
-          if (!isStateTest) {
-            window._mcpExecuting[codeHash] = true;
-          }
 
           let result;
           ${buildEvalIife(args.code)}
-
-          setTimeout(() => {
-            if (!isStateTest && window._mcpExecuting) {
-              delete window._mcpExecuting[codeHash];
-            }
-          }, 1000);
 
           if (result === undefined && !rawCode.includes('window.') && !rawCode.includes('document.') && !rawCode.includes('||')) {
             return { success: false, error: 'Command returned undefined - element may not exist or action failed', result: null };
@@ -116,6 +93,13 @@ export const evalCommand = defineCommand({
         }
       })()
     `;
+    // Note: the in-renderer "_mcpExecuting[codeHash]" reentrancy guard was
+    // removed in v2.0.1 (#10). The per-target serialization queue in
+    // src/utils/electron-connection.ts:_evaluateQueueByTarget now provides
+    // ordering guarantees, and the old guard's 10-char base64 hash collided
+    // for codes sharing a prefix (e.g. "document.title" and
+    // "document.body.children.length" → same slot → false positive
+    // "Code already executing").
 
     const rawResult = await executeInElectron(javascriptCode, target);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,6 +37,21 @@ export const CLICK_BY_SELECTOR_RATE_LIMIT_MS = 1000;
 export const CLICK_BY_TEXT_RATE_LIMIT_MS = 2000;
 
 /**
+ * Minimum textual-match score required to accept an `electron_click_by_text`
+ * candidate. Below this, the command returns "confidence too low" instead of
+ * risking a misclick (#3).
+ *
+ * Calibration (see `scoreTextMatch` in src/utils/text-matching.ts):
+ *   - 100 = exact match
+ *   -  70 = target phrase appears at word boundary
+ *   -  50 = every target word matched at word boundary (any order)
+ *   - 10–19 = partial multi-word match
+ * Picking 50 rejects partial multi-word matches and bonus-only candidates,
+ * while accepting any field that contains all target words.
+ */
+export const CLICK_BY_TEXT_MIN_TEXT_SCORE = 50;
+
+/**
  * Prefix that `executeInElectron` (src/utils/electron-connection.ts) prepends
  * to every successful Runtime.evaluate result string. Centralized here so
  * `electron_eval` can detect the wrapper and avoid double-prefixing

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ config({ quiet: true });
 const server = new Server(
   {
     name: 'electron-mcp-server',
-    version: '2.0.0',
+    version: '2.0.1',
   },
   {
     capabilities: {

--- a/src/utils/electron-commands.ts
+++ b/src/utils/electron-commands.ts
@@ -2,7 +2,8 @@
  * Enhanced Electron interaction commands for React-based applications
  * Addresses common issues with form interactions, event handling, and state management
  */
-import { CLICK_BY_TEXT_RATE_LIMIT_MS } from '../constants';
+import { CLICK_BY_TEXT_MIN_TEXT_SCORE, CLICK_BY_TEXT_RATE_LIMIT_MS } from '../constants';
+import { TEXT_MATCH_HELPERS_JS } from './text-matching';
 
 /**
  * Securely escape text input for JavaScript code generation
@@ -355,12 +356,16 @@ export function generateClickByTextCommand(text: string): string {
   return `
     (function() {
       const targetText = ${escapedText};  // Safe: JSON.stringify escapes quotes and special chars
-      
+
+      // Inlined helpers from src/utils/text-matching.ts (single source of truth,
+      // also exercised by tests/unit/text-matching.test.ts).
+      ${TEXT_MATCH_HELPERS_JS}
+
       // Deep DOM analysis function
       function analyzeElement(el) {
         const rect = el.getBoundingClientRect();
         const style = getComputedStyle(el);
-        
+
         return {
           element: el,
           text: (el.textContent || '').trim(),
@@ -374,88 +379,58 @@ export function generateClickByTextCommand(text: string): string {
           opacity: parseFloat(style.opacity) || 1
         };
       }
-      
-      // Score element relevance
+
+      // Score element relevance.
+      // textScore (0..100) is the gate — bonuses are tie-breakers on top.
+      // Pre-fix this function gave bonus-only scores to text-unrelated elements
+      // (e.g. "Heavy Math" matched "Fetch Data" via positional char similarity → #3).
       function scoreElement(analysis, target) {
-        let score = 0;
-        const text = analysis.text.toLowerCase();
-        const label = analysis.ariaLabel.toLowerCase();
-        const title = analysis.title.toLowerCase();
-        const targetLower = target.toLowerCase();
-        
-        // Exact match gets highest score
-        if (text === targetLower || label === targetLower || title === targetLower) score += 100;
-        
-        // Starts with target
-        if (text.startsWith(targetLower) || label.startsWith(targetLower)) score += 50;
-        
-        // Contains target
-        if (text.includes(targetLower) || label.includes(targetLower) || title.includes(targetLower)) score += 25;
-        
-        // Fuzzy matching for close matches
-        const similarity = Math.max(
-          calculateSimilarity(text, targetLower),
-          calculateSimilarity(label, targetLower),
-          calculateSimilarity(title, targetLower)
+        const textScore = scoreTextMatch(
+          analysis.text,
+          analysis.ariaLabel,
+          analysis.title,
+          target
         );
-        score += similarity * 20;
-        
-        // Bonus for interactive elements
+        if (textScore === 0) return { score: 0, textScore: 0 };
+
+        let score = textScore;
         if (analysis.isInteractive) score += 10;
-        
-        // Bonus for visibility
         if (analysis.isVisible) score += 15;
-        
-        // Bonus for larger elements (more likely to be main buttons)
         if (analysis.rect.width > 100 && analysis.rect.height > 30) score += 5;
-        
-        // Bonus for higher z-index (on top)
         score += Math.min(analysis.zIndex, 5);
-        
-        return score;
+        return { score: score, textScore: textScore };
       }
-      
-      // Simple string similarity function
-      function calculateSimilarity(str1, str2) {
-        const len1 = str1.length;
-        const len2 = str2.length;
-        const maxLen = Math.max(len1, len2);
-        if (maxLen === 0) return 0;
-        
-        let matches = 0;
-        const minLen = Math.min(len1, len2);
-        for (let i = 0; i < minLen; i++) {
-          if (str1[i] === str2[i]) matches++;
-        }
-        return matches / maxLen;
-      }
-      
+
       // Find all potentially clickable elements
       const allElements = document.querySelectorAll('*');
       const candidates = [];
-      
+
       for (let el of allElements) {
         const analysis = analyzeElement(el);
-        
+
         if (analysis.isVisible && (analysis.isInteractive || analysis.text || analysis.ariaLabel)) {
-          const score = scoreElement(analysis, targetText);
-          if (score > 5) { // Only consider elements with some relevance
-            candidates.push({ ...analysis, score });
+          const scored = scoreElement(analysis, targetText);
+          // textScore === 0 means no textual relation — drop it so bonuses
+          // alone (visibility/interactivity) cannot promote noise.
+          if (scored.textScore > 0) {
+            candidates.push({ ...analysis, score: scored.score, textScore: scored.textScore });
           }
         }
       }
-      
+
       if (candidates.length === 0) {
         return \`No clickable elements found containing text: "\${targetText}"\`;
       }
-      
+
       // Sort by score and get the best match
       candidates.sort((a, b) => b.score - a.score);
       const best = candidates[0];
-      
-      // Additional validation before clicking
-      if (best.score < 15) {
-        return \`Found potential matches but confidence too low (score: \${best.score}). Best match was: "\${best.text || best.ariaLabel}" - try being more specific.\`;
+
+      // Require strong textual evidence before clicking. CLICK_BY_TEXT_MIN_TEXT_SCORE
+      // is interpolated from src/utils/text-matching.ts and tracks the same
+      // calibration the unit tests assert (50 = "all target words at word boundaries").
+      if (best.textScore < ${CLICK_BY_TEXT_MIN_TEXT_SCORE}) {
+        return \`Found potential matches but confidence too low (textScore: \${best.textScore}, total: \${best.score}). Best match was: "\${best.text || best.ariaLabel}" - try being more specific.\`;
       }
       
       // Enhanced clicking for React components with duplicate prevention

--- a/src/utils/electron-connection.ts
+++ b/src/utils/electron-connection.ts
@@ -150,6 +150,31 @@ export interface ExecuteInElectronOptions {
 }
 
 /**
+ * Per-target serialization queue for `executeInElectron` (#10).
+ *
+ * Why this exists:
+ * CDP's `Runtime.evaluate` does not serialize concurrent in-flight calls
+ * against the same execution context. v2.0.0 had an in-renderer reentrancy
+ * guard (`window._mcpExecuting[codeHash]`) in the eval IIFE, but its
+ * 10-character base64 hash collided for codes sharing a prefix — e.g.
+ * `document.title` and `document.body.children.length` both hashed to
+ * `ZG9jdW1lbn`, raising spurious "Code already executing" failures on
+ * legitimately distinct concurrent calls.
+ *
+ * v2.0.1 removes the in-renderer guard and serializes here instead: a
+ * Promise-chain queue keyed by `targetInfo.id`. Within a single target,
+ * synchronous calls run strictly sequentially. Across different targets they
+ * remain fully parallel.
+ *
+ * `awaitPromise: true` callers BYPASS the queue (see `executeInElectron`).
+ * Wait/observer commands are long-lived by design and must not block actions
+ * that fire the events they are observing.
+ *
+ * Exported for tests only — production code must not touch it.
+ */
+export const _evaluateQueueByTarget = new Map<string, Promise<unknown>>();
+
+/**
  * Execute JavaScript code in an Electron application via Chrome DevTools Protocol.
  * @param javascriptCode - Expression to run in the Electron renderer
  * @param target - Optional DevTools target; defaults to the first discovered window
@@ -168,6 +193,50 @@ export async function executeInElectron(
     throw new Error('No WebSocket debugger URL available');
   }
 
+  // awaitPromise=true callers (wait_for_*, scroll_*, eval IIFEs returning a
+  // Promise) are long-lived passive observers that must NOT block the queue.
+  // The canonical async-UI pattern is `Promise.all([wait_for_X, action])` —
+  // serializing the wait would queue the action behind it, the action's side
+  // effect (which the wait is observing) never fires, the wait times out and
+  // the action runs belatedly. Bypass the queue: CDP itself happily handles
+  // concurrent in-flight `Runtime.evaluate` calls; the queue only exists to
+  // give synchronous evals on the same target a deterministic order.
+  if (options?.awaitPromise === true) {
+    return doEvaluate(targetInfo, javascriptCode, options);
+  }
+
+  // Per-target serialization (#10) for synchronous evals. Chain this call after
+  // the previous one for the same targetId. `.catch(() => undefined)` prevents
+  // a previous failure from failing this caller — each call's outcome is its own.
+  const queueKey = targetInfo.id;
+  const previous = _evaluateQueueByTarget.get(queueKey) ?? Promise.resolve();
+  const next = previous
+    .catch(() => undefined)
+    .then(() => doEvaluate(targetInfo, javascriptCode, options));
+
+  _evaluateQueueByTarget.set(queueKey, next);
+
+  // Cleanup tail entries to keep the map bounded. Only delete if we are still
+  // the tail; otherwise a later caller has chained on and owns the slot.
+  // Use .then(cleanup, cleanup) instead of .finally() so the cleanup chain
+  // observes any rejection — `.finally` returns a new Promise that re-throws,
+  // and we never await it, which would otherwise surface as an unhandled
+  // rejection. The real caller still sees rejection via `await next`.
+  const cleanup = () => {
+    if (_evaluateQueueByTarget.get(queueKey) === next) {
+      _evaluateQueueByTarget.delete(queueKey);
+    }
+  };
+  next.then(cleanup, cleanup);
+
+  return next;
+}
+
+async function doEvaluate(
+  targetInfo: DevToolsTarget,
+  javascriptCode: string,
+  options?: ExecuteInElectronOptions,
+): Promise<string> {
   logger.debug(`Executing JavaScript code on ${targetInfo.title}...`);
   let payload: RuntimeEvaluateResultPayload;
   try {

--- a/src/utils/electron-input-commands.ts
+++ b/src/utils/electron-input-commands.ts
@@ -474,7 +474,35 @@ export function generatePageStructureCommand(): string {
       };
       
       function detectFramework() {
+        // Legacy React signals (React ≤17, or when bundler exposes window.React).
         if (window.React || document.querySelector('[data-reactroot]')) return 'React';
+        // React 18+ Fiber roots: each mount-point DOM node carries a property
+        // named like "__reactContainer$<random>". Scan common root selectors
+        // (#root for Vite/CRA, #app for many setups, #__next for Next.js)
+        // plus the first few body children to catch arbitrary mount points.
+        var fiberRootSelectors = ['#root', '#app', '#__next'];
+        var fiberCandidates = [];
+        for (var i = 0; i < fiberRootSelectors.length; i++) {
+          var rootEl = document.querySelector(fiberRootSelectors[i]);
+          if (rootEl) fiberCandidates.push(rootEl);
+        }
+        if (document.body) {
+          var bodyChildren = document.body.children;
+          for (var j = 0; j < Math.min(bodyChildren.length, 5); j++) {
+            fiberCandidates.push(bodyChildren[j]);
+          }
+        }
+        for (var k = 0; k < fiberCandidates.length; k++) {
+          var keys = Object.keys(fiberCandidates[k]);
+          for (var m = 0; m < keys.length; m++) {
+            if (keys[m].indexOf('__reactContainer') === 0) return 'React';
+          }
+        }
+        // React DevTools hook with attached renderers (covers exotic mounts).
+        var devtoolsHook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+        if (devtoolsHook && devtoolsHook.renderers && devtoolsHook.renderers.size > 0) {
+          return 'React';
+        }
         if (window.Vue || document.querySelector('[data-v-]')) return 'Vue';
         if (window.angular || document.querySelector('[ng-version]')) return 'Angular';
         return 'Unknown';

--- a/src/utils/text-matching.ts
+++ b/src/utils/text-matching.ts
@@ -1,0 +1,107 @@
+/**
+ * Text matching scoring helpers for `electron_click_by_text`.
+ *
+ * Why a string-source export?
+ * The scoring runs **inside the Electron renderer** (sent over CDP as a code
+ * string and evaluated). To unit-test the same algorithm in vitest we'd need
+ * either a parallel TS implementation (drift risk) or a way to load the JS
+ * source into a sandbox. Exporting the helpers as a JS source string lets us:
+ *   - Inline them into the IIFE that goes over CDP (see `generateClickByTextCommand`)
+ *   - Load them into a `new Function(...)` sandbox in tests (see `tests/unit/text-matching.test.ts`)
+ * Single source of truth, both sides exercise the exact same characters.
+ *
+ * Webpack ships in `mode: 'production'` with `minimize: false` (see
+ * `webpack.config.ts`), so this template string is preserved verbatim.
+ */
+export const TEXT_MATCH_HELPERS_JS = `
+function isWordChar(ch) {
+  if (!ch) return false;
+  var code = ch.charCodeAt(0);
+  // ASCII alphanumeric: 0-9, A-Z, a-z. UI text matching does not need full
+  // Unicode word semantics — the CJK-text use case goes through exact-match
+  // (no word splitting), and Latin labels are well-served by ASCII bounds.
+  return (code >= 48 && code <= 57)
+      || (code >= 65 && code <= 90)
+      || (code >= 97 && code <= 122);
+}
+
+function containsAsWord(haystack, needle) {
+  if (!needle || !haystack) return false;
+  var idx = haystack.indexOf(needle);
+  while (idx !== -1) {
+    var beforeChar = idx === 0 ? '' : haystack.charAt(idx - 1);
+    var afterPos = idx + needle.length;
+    var afterChar = afterPos >= haystack.length ? '' : haystack.charAt(afterPos);
+    if (!isWordChar(beforeChar) && !isWordChar(afterChar)) return true;
+    idx = haystack.indexOf(needle, idx + 1);
+  }
+  return false;
+}
+
+function tokenizeTarget(target) {
+  // Split on space character only. Empty tokens dropped.
+  var raw = target.split(' ');
+  var out = [];
+  for (var i = 0; i < raw.length; i++) {
+    var token = raw[i];
+    if (token && token.length > 0) out.push(token);
+  }
+  return out;
+}
+
+/**
+ * Score how strongly target matches the given fields. Returns 0 when no
+ * meaningful textual relation exists — this gates the candidate list and
+ * is what fixes the "Heavy Math → Fetch Data" false-positive (#3): the
+ * old positional similarity gave 4/10 = 0.4 → +8 from coincidental
+ * character alignment plus visibility/interactivity bonuses, summing to 38.
+ *
+ * Score levels:
+ *   100 — full string equality on any field
+ *    70 — target appears as a contiguous phrase at word boundaries
+ *    50 — every word in target appears at word boundaries (any order)
+ *  10-19 — partial: ≥50% of target words present (only for multi-word targets)
+ *     0 — no textual relation; element is filtered out
+ *
+ * Visibility/interactivity bonuses are applied by the caller on top of this.
+ */
+function scoreTextMatch(text, label, title, target) {
+  var targetLower = (target || '').toLowerCase().trim();
+  if (!targetLower) return 0;
+
+  var fields = [];
+  var rawFields = [text, label, title];
+  for (var rfi = 0; rfi < rawFields.length; rfi++) {
+    var raw = (rawFields[rfi] || '').toLowerCase().trim();
+    if (raw.length > 0) fields.push(raw);
+  }
+  if (fields.length === 0) return 0;
+
+  var targetWords = tokenizeTarget(targetLower);
+
+  var best = 0;
+  for (var fi = 0; fi < fields.length; fi++) {
+    var field = fields[fi];
+    var fieldScore = 0;
+    if (field === targetLower) {
+      fieldScore = 100;
+    } else if (containsAsWord(field, targetLower)) {
+      fieldScore = 70;
+    } else if (targetWords.length >= 2) {
+      var matched = 0;
+      for (var wi = 0; wi < targetWords.length; wi++) {
+        if (containsAsWord(field, targetWords[wi])) matched++;
+      }
+      if (matched === targetWords.length) {
+        fieldScore = 50;
+      } else if (matched > 0 && (matched / targetWords.length) >= 0.5) {
+        // Partial multi-word match: low score, will only win if nothing
+        // better exists and the accept threshold is satisfied.
+        fieldScore = Math.round(20 * (matched / targetWords.length));
+      }
+    }
+    if (fieldScore > best) best = fieldScore;
+  }
+  return best;
+}
+`;

--- a/tests/unit/eval-serialization.test.ts
+++ b/tests/unit/eval-serialization.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the CDP pool BEFORE importing executeInElectron so the module sees
+// the mocked singleton.
+const evaluateMock = vi.hoisted(() =>
+  vi.fn(async (_target: unknown, _code: string, _opts?: unknown) => ({
+    result: { type: 'string' as const, value: 'mocked' },
+  })),
+);
+
+vi.mock('../../src/utils/cdp-pool', () => ({
+  CdpConnectionPool: {
+    getInstance: () => ({ evaluate: evaluateMock }),
+  },
+}));
+
+import {
+  executeInElectron,
+  _evaluateQueueByTarget,
+  type DevToolsTarget,
+} from '../../src/utils/electron-connection';
+
+const targetA: DevToolsTarget = {
+  id: 'target-A',
+  title: 'Window A',
+  url: 'file:///a',
+  type: 'page',
+  webSocketDebuggerUrl: 'ws://localhost:9222/devtools/page/target-A',
+};
+
+const targetB: DevToolsTarget = {
+  id: 'target-B',
+  title: 'Window B',
+  url: 'file:///b',
+  type: 'page',
+  webSocketDebuggerUrl: 'ws://localhost:9222/devtools/page/target-B',
+};
+
+/**
+ * Build a controllable promise for use as the mock evaluate response.
+ * Pair the returned `promise` with `resolve()`/`reject()` to drive timing
+ * deterministically.
+ */
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (err: Error) => void } {
+  let resolve!: (value: T) => void;
+  let reject!: (err: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  evaluateMock.mockReset();
+  _evaluateQueueByTarget.clear();
+});
+
+afterEach(() => {
+  _evaluateQueueByTarget.clear();
+});
+
+describe('executeInElectron — Issue #10 per-target serialization', () => {
+  it('serializes 3 parallel calls on the same targetId', async () => {
+    // Arrange: each evaluate call returns a controllable deferred promise.
+    // Track the order in which the mock was entered to prove no overlap.
+    const callOrder: string[] = [];
+    const completionOrder: string[] = [];
+    const deferreds = [deferred<{ result: { type: 'string'; value: string } }>(),
+                       deferred<{ result: { type: 'string'; value: string } }>(),
+                       deferred<{ result: { type: 'string'; value: string } }>()];
+    let callCount = 0;
+
+    evaluateMock.mockImplementation(async (_t: unknown, code: string) => {
+      const idx = callCount++;
+      callOrder.push(code);
+      const result = await deferreds[idx].promise;
+      completionOrder.push(code);
+      return result;
+    });
+
+    // Act: fire 3 calls on the same target without awaiting.
+    const p1 = executeInElectron('code-1', targetA);
+    const p2 = executeInElectron('code-2', targetA);
+    const p3 = executeInElectron('code-3', targetA);
+
+    // Yield so call #1 can enter the mock.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(callOrder).toEqual(['code-1']);
+
+    // Resolve #1 → #2 may now enter.
+    deferreds[0].resolve({ result: { type: 'string', value: 'r1' } });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(callOrder).toEqual(['code-1', 'code-2']);
+
+    // Resolve #2 → #3 may now enter.
+    deferreds[1].resolve({ result: { type: 'string', value: 'r2' } });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(callOrder).toEqual(['code-1', 'code-2', 'code-3']);
+
+    // Resolve #3.
+    deferreds[2].resolve({ result: { type: 'string', value: 'r3' } });
+
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+    expect(r1).toBe('✅ Command executed: r1');
+    expect(r2).toBe('✅ Command executed: r2');
+    expect(r3).toBe('✅ Command executed: r3');
+
+    expect(completionOrder).toEqual(['code-1', 'code-2', 'code-3']);
+  });
+
+  it('runs calls on different targets fully in parallel', async () => {
+    // Both calls enter the mock before either resolves — proves no
+    // cross-target serialization.
+    const dA = deferred<{ result: { type: 'string'; value: string } }>();
+    const dB = deferred<{ result: { type: 'string'; value: string } }>();
+
+    let active = 0;
+    let maxConcurrent = 0;
+    evaluateMock.mockImplementation(async (target: any) => {
+      active++;
+      maxConcurrent = Math.max(maxConcurrent, active);
+      const d = target.id === 'target-A' ? dA : dB;
+      const r = await d.promise;
+      active--;
+      return r;
+    });
+
+    const pA = executeInElectron('on-A', targetA);
+    const pB = executeInElectron('on-B', targetB);
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(maxConcurrent).toBe(2);
+
+    dA.resolve({ result: { type: 'string', value: 'a' } });
+    dB.resolve({ result: { type: 'string', value: 'b' } });
+    await Promise.all([pA, pB]);
+  });
+
+  it('does not propagate previous failure to next caller', async () => {
+    let callIndex = 0;
+    evaluateMock.mockImplementation(async () => {
+      callIndex++;
+      if (callIndex === 1) throw new Error('boom');
+      return { result: { type: 'string' as const, value: 'ok' } };
+    });
+
+    const failing = executeInElectron('will-fail', targetA);
+    const succeeding = executeInElectron('will-succeed', targetA);
+
+    await expect(failing).rejects.toThrow(/DevTools Protocol error: boom/);
+    await expect(succeeding).resolves.toBe('✅ Command executed: ok');
+  });
+
+  it('cleans up the queue map after the tail resolves', async () => {
+    evaluateMock.mockResolvedValue({ result: { type: 'string', value: 'ok' } });
+
+    await executeInElectron('one-call', targetA);
+    // Allow the .then(cleanup, cleanup) microtask to run.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(_evaluateQueueByTarget.has('target-A')).toBe(false);
+    expect(_evaluateQueueByTarget.size).toBe(0);
+  });
+
+  it('cleans up after a rejected call too', async () => {
+    evaluateMock.mockRejectedValue(new Error('boom'));
+
+    await expect(executeInElectron('bad', targetA)).rejects.toThrow();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(_evaluateQueueByTarget.has('target-A')).toBe(false);
+  });
+
+  /**
+   * Regression test for the deadlock found in v2.0.1 adversarial review:
+   * `Promise.all([wait_for_*, action])` is the canonical async-UI pattern,
+   * and serializing the wait would queue the action behind it. The wait blocks
+   * until its trigger fires, but the trigger is queued — deadlock until the
+   * wait's user timeout. Internal wait/observer commands pass `awaitPromise: true`
+   * to flag this; `executeInElectron` must bypass the queue for those.
+   */
+  it('bypasses the queue when awaitPromise: true', async () => {
+    const callOrder: string[] = [];
+    const waitDeferred = deferred<{ result: { type: 'string'; value: string } }>();
+    let callCount = 0;
+
+    evaluateMock.mockImplementation(async (_t: unknown, code: string) => {
+      callOrder.push(`enter:${code}`);
+      const idx = callCount++;
+      // First call (the wait) holds open until we explicitly resolve it.
+      // The action call must enter immediately even though the wait hasn't returned.
+      if (idx === 0) {
+        await waitDeferred.promise;
+      }
+      callOrder.push(`exit:${code}`);
+      return { result: { type: 'string', value: code } };
+    });
+
+    // Fire wait (awaitPromise: true) and a synchronous action concurrently.
+    const waitCall = executeInElectron('wait-for-something', targetA, { awaitPromise: true });
+    const actionCall = executeInElectron('action-that-triggers-it', targetA);
+
+    // Action must enter the mock BEFORE the wait resolves — proves it didn't queue.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(callOrder).toContain('enter:action-that-triggers-it');
+    expect(callOrder).toContain('exit:action-that-triggers-it');
+
+    // Now resolve the wait; both calls finish.
+    waitDeferred.resolve({ result: { type: 'string', value: 'wait-for-something' } });
+    await Promise.all([waitCall, actionCall]);
+  });
+
+  /**
+   * The bypass must only affect awaitPromise=true callers — synchronous evals
+   * still need ordering (e.g., `window.x = 1` then `read window.x`).
+   */
+  it('still serializes synchronous evals when an awaitPromise call is in-flight', async () => {
+    const callOrder: string[] = [];
+    const syncDeferreds = [deferred<{ result: { type: 'string'; value: string } }>(),
+                           deferred<{ result: { type: 'string'; value: string } }>()];
+    let syncIdx = 0;
+
+    evaluateMock.mockImplementation(async (_t: unknown, code: string) => {
+      callOrder.push(`enter:${code}`);
+      if (code === 'wait') {
+        // Resolve immediately — we only care about ordering of the two sync calls.
+        return { result: { type: 'string', value: 'wait-done' } };
+      }
+      const result = await syncDeferreds[syncIdx++].promise;
+      callOrder.push(`exit:${code}`);
+      return result;
+    });
+
+    const waitCall = executeInElectron('wait', targetA, { awaitPromise: true });
+    const sync1 = executeInElectron('sync-1', targetA);
+    const sync2 = executeInElectron('sync-2', targetA);
+
+    await waitCall;
+    // Resolve sync-1 first; sync-2 must not have entered yet.
+    syncDeferreds[0].resolve({ result: { type: 'string', value: 'sync-1' } });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(callOrder).not.toContain('enter:sync-2');
+    syncDeferreds[1].resolve({ result: { type: 'string', value: 'sync-2' } });
+    await Promise.all([sync1, sync2]);
+    expect(callOrder.indexOf('exit:sync-1')).toBeLessThan(callOrder.indexOf('enter:sync-2'));
+  });
+});

--- a/tests/unit/text-matching.test.ts
+++ b/tests/unit/text-matching.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { CLICK_BY_TEXT_MIN_TEXT_SCORE } from '../../src/constants';
+import { TEXT_MATCH_HELPERS_JS } from '../../src/utils/text-matching';
+
+/**
+ * Load the text-matching helpers from the JS source string into a sandbox so
+ * we exercise the *exact same characters* that get sent to the Electron
+ * renderer over CDP. Avoids drift between the tested algorithm and the one
+ * that runs in production.
+ */
+type Helpers = {
+  scoreTextMatch: (text: string, label: string, title: string, target: string) => number;
+  containsAsWord: (haystack: string, needle: string) => boolean;
+};
+
+function loadHelpers(): Helpers {
+  const exports: Record<string, unknown> = {};
+  // eslint-disable-next-line no-new-func -- intentional: we want to evaluate the
+  // source string the renderer will actually run, in a controlled vitest sandbox.
+  new Function(
+    'exports',
+    `${TEXT_MATCH_HELPERS_JS}
+    exports.scoreTextMatch = scoreTextMatch;
+    exports.containsAsWord = containsAsWord;`,
+  )(exports);
+  return exports as unknown as Helpers;
+}
+
+const { scoreTextMatch, containsAsWord } = loadHelpers();
+
+describe('containsAsWord', () => {
+  it('matches whole word at start', () => {
+    expect(containsAsWord('fetch data', 'fetch')).toBe(true);
+  });
+
+  it('matches whole word at end', () => {
+    expect(containsAsWord('fetch data', 'data')).toBe(true);
+  });
+
+  it('matches whole word in middle', () => {
+    expect(containsAsWord('click the submit button', 'submit')).toBe(true);
+  });
+
+  it('rejects substring inside larger word', () => {
+    expect(containsAsWord('submitting', 'submit')).toBe(false);
+    expect(containsAsWord('database', 'data')).toBe(false);
+  });
+
+  it('returns false on empty inputs', () => {
+    expect(containsAsWord('', 'fetch')).toBe(false);
+    expect(containsAsWord('fetch data', '')).toBe(false);
+  });
+
+  it('treats hyphens and punctuation as boundaries', () => {
+    expect(containsAsWord('save-as', 'save')).toBe(true);
+    expect(containsAsWord('save:as', 'as')).toBe(true);
+  });
+});
+
+describe('scoreTextMatch — Issue #3 regression', () => {
+  it('returns 0 for unrelated short strings (Heavy Math ↔ Fetch Data)', () => {
+    // The original bug: positional char similarity gave 4/10 → +8 score, plus
+    // visibility/interactivity bonuses summed to 38 → false-positive misclick.
+    // Fix verifies textScore is 0, so candidate is filtered out entirely.
+    expect(scoreTextMatch('Fetch Data', '', '', 'Heavy Math')).toBe(0);
+  });
+
+  it('rejects below CLICK_BY_TEXT_MIN_TEXT_SCORE threshold', () => {
+    // Sanity: the threshold the renderer-side IIFE uses really does reject
+    // the original false-positive.
+    const score = scoreTextMatch('Fetch Data', '', '', 'Heavy Math');
+    expect(score).toBeLessThan(CLICK_BY_TEXT_MIN_TEXT_SCORE);
+  });
+
+  it('returns 0 when target shares only individual chars with field', () => {
+    // Catches the broken positional algorithm from another angle.
+    expect(scoreTextMatch('Cancel', '', '', 'Submit')).toBe(0);
+  });
+});
+
+describe('scoreTextMatch — exact and phrase matches', () => {
+  it('returns 100 on exact match in text', () => {
+    expect(scoreTextMatch('Submit', '', '', 'Submit')).toBe(100);
+  });
+
+  it('returns 100 on exact match in aria-label', () => {
+    expect(scoreTextMatch('', 'Close dialog', '', 'Close dialog')).toBe(100);
+  });
+
+  it('returns 70 when target appears as contiguous phrase at word boundaries', () => {
+    expect(scoreTextMatch('Click the Submit button', '', '', 'Submit button')).toBe(70);
+  });
+
+  it('returns 70 even if surrounded by punctuation', () => {
+    expect(scoreTextMatch('[Save File]', '', '', 'Save File')).toBe(70);
+  });
+
+  it('is case-insensitive', () => {
+    expect(scoreTextMatch('SUBMIT', '', '', 'submit')).toBe(100);
+    expect(scoreTextMatch('Submit', '', '', 'SUBMIT')).toBe(100);
+  });
+});
+
+describe('scoreTextMatch — multi-word matches', () => {
+  it('returns 50 when all target words present at word boundaries (any order)', () => {
+    // "Heavy Math" target, "Math Heavy" text → all words present, different order
+    expect(scoreTextMatch('Math Heavy', '', '', 'Heavy Math')).toBe(50);
+  });
+
+  it('returns ≥ MIN threshold when all target words match', () => {
+    const score = scoreTextMatch('Math Heavy', '', '', 'Heavy Math');
+    expect(score).toBeGreaterThanOrEqual(CLICK_BY_TEXT_MIN_TEXT_SCORE);
+  });
+
+  it('returns partial score (< MIN) for half-word match on multi-word target', () => {
+    // Only 'Math' present → 1/2 words. This is ambiguous, must NOT auto-accept.
+    const score = scoreTextMatch('Math Solver', '', '', 'Heavy Math');
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThan(CLICK_BY_TEXT_MIN_TEXT_SCORE);
+  });
+
+  it('returns 0 for partial single-word target (no fuzzy fallback)', () => {
+    // Single-word target can't be "partial" — either matches the word or not.
+    // (No more positional fuzzy matching that would incorrectly score this.)
+    expect(scoreTextMatch('Submitting', '', '', 'Submit')).toBe(0);
+  });
+});
+
+describe('scoreTextMatch — field selection', () => {
+  it('takes the strongest signal across text/label/title', () => {
+    // text doesn't match but aria-label does
+    expect(scoreTextMatch('Icon', 'Save File', '', 'Save File')).toBe(100);
+  });
+
+  it('does not double-count across fields (max, not sum)', () => {
+    // Three exact matches still scores 100, not 300.
+    expect(scoreTextMatch('Submit', 'Submit', 'Submit', 'Submit')).toBe(100);
+  });
+
+  it('handles empty target safely', () => {
+    expect(scoreTextMatch('any text', '', '', '')).toBe(0);
+  });
+
+  it('handles empty fields safely', () => {
+    expect(scoreTextMatch('', '', '', 'Submit')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Three non-Critical bugs left over from v2.0.0:

- **#20** React 19 framework detection — Fiber-root prefix scan (`__reactContainer$<n>`) restores detection for React 18+ apps
- **#3** `click_by_text` false-positive scoring — replaces broken positional char-similarity with word-boundary scoring (`Heavy Math` no longer hits `Fetch Data`)
- **#10** Parallel eval serialization — per-target Promise-chain queue + `awaitPromise: true` bypass to avoid `Promise.all([wait_for_*, action])` deadlock

## Highlights

### #20 — React 19 detection
`detectFramework()` in `electron-input-commands.ts` now scans `#root` / `#app` / `#__next` / first 5 body children for any property prefixed with `__reactContainer` (React 18+ Fiber convention). Falls back to `__REACT_DEVTOOLS_GLOBAL_HOOK__.renderers.size > 0`.

### #3 — Word-boundary text scoring
New `src/utils/text-matching.ts` exports `TEXT_MATCH_HELPERS_JS` as a JS source string (single source of truth — same characters run in the Electron renderer over CDP and in the vitest `new Function()` sandbox).

| Score | Meaning |
|---|---|
| 100 | Exact match |
| 70  | Target appears as contiguous phrase at word boundaries |
| 50  | All target words appear at word boundaries (any order) |
| 10–19 | Partial multi-word match (≥50%) |
| 0   | No textual relation; element filtered out |

`CLICK_BY_TEXT_MIN_TEXT_SCORE = 50` in `src/constants.ts`.

### #10 — Per-target serialization queue
`_evaluateQueueByTarget = new Map<string, Promise<unknown>>()` in `electron-connection.ts`. Synchronous `executeInElectron` calls on the same target chain off the previous Promise; cross-target calls remain fully parallel.

Replaces the old in-renderer `_mcpExecuting[codeHash]` reentrancy guard whose 10-char base64 hash collided for prefix-sharing codes (`document.title` and `document.body.children.length` both → `ZG9jdW1lbn`).

**Adversarial-review fix:** `awaitPromise: true` callers (5 wait commands + 2 scroll commands) bypass the queue. Without the bypass, `Promise.all([wait_for_selector, click_by_selector])` would deadlock — the wait holds the queue head waiting for a trigger that the action (queued behind it) is supposed to fire.

Cleanup uses `next.then(cleanup, cleanup)` instead of `.finally(cleanup)` to avoid unhandled rejections (`.finally` returns a re-throwing Promise that's never awaited).

## Test plan

- [x] `npx vitest run tests/unit/text-matching.test.ts` — 22 pass (word-boundary scoring incl. "Heavy Math vs Fetch Data" regression)
- [x] `npx vitest run tests/unit/eval-serialization.test.ts` — 7 pass (queue serialize, cross-target parallel, failure isolation, cleanup, awaitPromise bypass + sync co-existence ordering)
- [x] `npm test` — 144 pass, 33 skipped (require live Electron fixture). Pre-existing `electron-security-integration.test.ts` hook timeout flake is unrelated.
- [x] `npm run code:check` — lint + format clean
- [x] `npm run build` — webpack production bundle 340 KiB
- [ ] Live qa-fixture validation (electron-vite + React 19 + react-router-dom v7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced text-matching for click-by-text operations with improved confidence scoring.
  * Added per-target serialization for Electron command execution.
  * Improved React 18+ framework detection capabilities.

* **Bug Fixes**
  * Removed problematic deduplication logic that could interfere with command execution.

* **Tests**
  * Added comprehensive test coverage for serialization and text-matching functionality.

* **Chores**
  * Bumped version to 2.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->